### PR TITLE
persist public url in settings

### DIFF
--- a/backend/syftai_space/alembic/versions/e18675e6eecb_add_settings_table.py
+++ b/backend/syftai_space/alembic/versions/e18675e6eecb_add_settings_table.py
@@ -1,0 +1,33 @@
+"""add settings table
+
+Revision ID: e18675e6eecb
+Revises: 9b73c6b77fa4
+Create Date: 2026-01-13 12:39:41.971893
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel  # noqa: F401 - Added for SQLModel support
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e18675e6eecb"
+down_revision: str | None = "9b73c6b77fa4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "settings",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("public_url", sa.String(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("settings")

--- a/backend/syftai_space/components/settings/__init__.py
+++ b/backend/syftai_space/components/settings/__init__.py
@@ -1,13 +1,17 @@
 """Settings component for public URL management."""
 
+from syftai_space.components.settings.entities import Settings
 from syftai_space.components.settings.handlers import SettingsHandler
+from syftai_space.components.settings.repository import SettingsRepository
 from syftai_space.components.settings.schemas import (
     PublicUrlResponse,
     UpdatePublicUrlRequest,
 )
 
 __all__ = [
+    "Settings",
     "SettingsHandler",
+    "SettingsRepository",
     "PublicUrlResponse",
     "UpdatePublicUrlRequest",
 ]

--- a/backend/syftai_space/components/settings/entities.py
+++ b/backend/syftai_space/components/settings/entities.py
@@ -1,0 +1,17 @@
+"""Settings database entities."""
+
+from datetime import datetime, timezone
+
+from sqlmodel import Field, SQLModel
+
+
+class Settings(SQLModel, table=True):
+    """Application settings entity - singleton row (id=1)."""
+
+    __tablename__ = "settings"
+
+    id: int = Field(default=1, primary_key=True)
+    public_url: str | None = Field(
+        default=None, description="Public URL for the SyftAI Space"
+    )
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/backend/syftai_space/components/settings/handlers.py
+++ b/backend/syftai_space/components/settings/handlers.py
@@ -4,6 +4,7 @@ from fastapi import HTTPException
 from pydantic import HttpUrl
 
 from syftai_space.components.marketplaces.handlers import MarketplaceHandler
+from syftai_space.components.settings.repository import SettingsRepository
 from syftai_space.components.settings.schemas import PublicUrlResponse
 from syftai_space.components.shared.syfthub_client import SyftHubClient, SyftHubError
 from syftai_space.components.tenants.entities import Tenant
@@ -14,33 +15,37 @@ class SettingsHandler:
     """Handler for settings business logic."""
 
     def __init__(
-        self, marketplace_handler: MarketplaceHandler, config: AppSettings
+        self,
+        settings_repository: SettingsRepository,
+        marketplace_handler: MarketplaceHandler,
+        config: AppSettings,
     ) -> None:
         """Initialize the settings handler.
 
         Args:
+            settings_repository: Repository for settings persistence
             marketplace_handler: Marketplace handler for syncing to SyftHub
             config: Application settings
         """
+        self.settings_repository = settings_repository
         self.marketplace_handler = marketplace_handler
         self.config = config
 
     def get_public_url(self) -> PublicUrlResponse:
-        """Get the current public URL.
+        """Get the current public URL from database (source of truth).
 
         Returns:
             Public URL response
         """
-        return PublicUrlResponse(
-            public_url=str(self.config.public_url) if self.config.public_url else None
-        )
+        settings = self.settings_repository.get_settings()
+        return PublicUrlResponse(public_url=settings.public_url)
 
     def update_public_url(
         self, tenant: Tenant, new_url: HttpUrl | str
     ) -> PublicUrlResponse:
         """Update the public URL.
 
-        Updates the local config and syncs to SyftHub marketplace.
+        Updates the database (source of truth) and syncs to SyftHub marketplace.
 
         Args:
             tenant: Tenant context
@@ -52,19 +57,18 @@ class SettingsHandler:
         Raises:
             HTTPException: If sync to marketplace fails
         """
-        # Convert to HttpUrl if str, then store
-        if isinstance(new_url, str):
-            new_url = HttpUrl(new_url)
+        # Convert to string for storage
+        url_str = str(new_url) if new_url else None
 
-        # Update local config
-        self.config.public_url = new_url
+        # Update database (source of truth)
+        self.settings_repository.update_public_url(url_str)
 
         # Sync to SyftHub if marketplace is configured
         try:
             marketplace = self.marketplace_handler.get_default_marketplace(tenant)
             with SyftHubClient(str(marketplace.url)) as syfthub:
                 syfthub.login(marketplace.email, marketplace.password)
-                syfthub.update_profile(domain=str(new_url))
+                syfthub.update_profile(domain=url_str)
         except HTTPException as e:
             if e.status_code == 404:
                 # No marketplace configured, just update local config
@@ -77,4 +81,12 @@ class SettingsHandler:
                 detail=f"Failed to sync public URL to marketplace: {e.message}",
             ) from e
 
-        return PublicUrlResponse(public_url=str(new_url))
+        return PublicUrlResponse(public_url=url_str)
+
+    def initialize_from_config(self) -> None:
+        """Initialize settings from config on startup.
+
+        If SYFT_PUBLIC_URL env var is set, it overwrites the database value.
+        """
+        if self.config.public_url:
+            self.settings_repository.update_public_url(str(self.config.public_url))

--- a/backend/syftai_space/components/settings/repository.py
+++ b/backend/syftai_space/components/settings/repository.py
@@ -1,0 +1,27 @@
+"""Settings repository for database operations."""
+
+from datetime import datetime, timezone
+
+from syftai_space.components.settings.entities import Settings
+from syftai_space.components.shared.database import BaseRepository, Database
+
+
+class SettingsRepository(BaseRepository[Settings]):
+    """Repository for Settings CRUD operations."""
+
+    def __init__(self, db: Database):
+        super().__init__(db, Settings)
+
+    def get_settings(self) -> Settings:
+        """Get the singleton settings row, creating if not exists."""
+        settings = self.get_by_id(1)
+        if not settings:
+            settings = self.create(Settings(id=1))
+        return settings
+
+    def update_public_url(self, url: str | None) -> Settings:
+        """Update the public_url setting."""
+        settings = self.get_settings()
+        settings.public_url = url
+        settings.updated_at = datetime.now(timezone.utc)
+        return self.update(settings)

--- a/backend/syftai_space/main.py
+++ b/backend/syftai_space/main.py
@@ -72,6 +72,7 @@ from syftai_space.components.policy_types.registry import POLICY_TYPE_REGISTRY
 from syftai_space.components.settings.handlers import SettingsHandler
 
 # Import settings components
+from syftai_space.components.settings.repository import SettingsRepository
 from syftai_space.components.settings.routes import build_settings_routes
 
 # Import database
@@ -110,7 +111,11 @@ async def lifespan(app: FastAPI):
             logger.info(f"📡 Public URL: {public_url}")
             logger.info(f"🔗 Local URL: http://localhost:{port}")
             logger.info("=" * 70 + "\n")
-            app_settings.public_url = public_url
+
+            # Update database via settings handler (source of truth)
+            settings_handler = getattr(app.state, "settings_handler", None)
+            if settings_handler:
+                settings_handler.settings_repository.update_public_url(public_url)
 
         except Exception as e:
             logger.error(f"⚠️  Warning: Failed to start ngrok tunnel: {e}")
@@ -243,7 +248,15 @@ endpoint_handler = EndpointHandler(
     marketplace_repository=marketplace_repository,
 )
 tenant_handler = TenantHandler(tenant_repository)
-settings_handler = SettingsHandler(marketplace_handler, app_settings)
+
+# Initialize settings repository and handler
+settings_repository = SettingsRepository(database)
+settings_handler = SettingsHandler(
+    settings_repository, marketplace_handler, app_settings
+)
+
+# Initialize settings from config on startup (env var overwrites DB if set)
+settings_handler.initialize_from_config()
 
 # Initialize ingestion manager and handler
 ingestion_manager = IngestionManager(
@@ -260,6 +273,7 @@ ingestion_handler = IngestionHandler(
 provisioner_manager = ProvisionerManager(dataset_handler)
 app.state.provisioner_manager = provisioner_manager
 app.state.ingestion_manager = ingestion_manager
+app.state.settings_handler = settings_handler
 
 # Add tenant middleware (after CORS, before routes)
 app.add_middleware(TenantMiddleware, tenant_repository=tenant_repository)


### PR DESCRIPTION
This pull request introduces a persistent settings system for managing the application's public URL, moving the source of truth from in-memory config to a database-backed singleton table. It adds a new `settings` table, a corresponding SQLModel entity, a repository for CRUD operations, and updates the handler and initialization logic to use this new persistence layer. The public URL is now consistently managed through the database, with initialization from environment variables if set.

**Database & Persistence Layer:**
- Added a new Alembic migration to create a `settings` table with fields for `id`, `public_url`, and `updated_at` (`e18675e6eecb_add_settings_table.py`).
- Introduced the `Settings` SQLModel entity and a `SettingsRepository` for CRUD operations on the singleton settings row. [[1]](diffhunk://#diff-fc13dd2aa085955806d16ff68e19aa300b3dbbfafb591b2f2285e35e2aed036eR1-R17) [[2]](diffhunk://#diff-e14c85edadb3de2d9db5ee4e48f0ebf46191b63198d3971eded69c7eecad006dR1-R27)

**Settings Handling Logic:**
- Refactored `SettingsHandler` to use `SettingsRepository` for all reads/writes of the public URL, making the database the source of truth. Added an `initialize_from_config` method to sync environment/config values to the database on startup. [[1]](diffhunk://#diff-9c3f12d44feffc4fe4763b4dc9563caaaec4360cfbf89fdc9c8b251b868630d1R7) [[2]](diffhunk://#diff-9c3f12d44feffc4fe4763b4dc9563caaaec4360cfbf89fdc9c8b251b868630d1L17-R48) [[3]](diffhunk://#diff-9c3f12d44feffc4fe4763b4dc9563caaaec4360cfbf89fdc9c8b251b868630d1L55-R71) [[4]](diffhunk://#diff-9c3f12d44feffc4fe4763b4dc9563caaaec4360cfbf89fdc9c8b251b868630d1L80-R92)

**Application Initialization:**
- Updated `main.py` to instantiate and register the new `SettingsRepository` and `SettingsHandler`, and to call `initialize_from_config` at startup. The app now updates the database (not just config) when the public URL is set via ngrok or environment variable. [[1]](diffhunk://#diff-243097ba675f5a376b71acb6bc2ef624eafa19af235c741dc42285674284c29cR75) [[2]](diffhunk://#diff-243097ba675f5a376b71acb6bc2ef624eafa19af235c741dc42285674284c29cL113-R118) [[3]](diffhunk://#diff-243097ba675f5a376b71acb6bc2ef624eafa19af235c741dc42285674284c29cL246-R259) [[4]](diffhunk://#diff-243097ba675f5a376b71acb6bc2ef624eafa19af235c741dc42285674284c29cR276)

**Imports & Module Exports:**
- Updated imports and `__all__` exports to include the new `Settings` entity and `SettingsRepository` in the settings component.

These changes ensure that the application's public URL is reliably persisted and synchronized across restarts and deployments, supporting future extensibility for other settings.