### PR TITLE
fix: auto-generate collectionName to fix HTTP context errors

### DIFF
--- a/backend/syft_space/components/dataset_types/weaviate_local/weaviate_type.py
+++ b/backend/syft_space/components/dataset_types/weaviate_local/weaviate_type.py
@@ -3,6 +3,7 @@
 import asyncio
 import re
 import threading
+import uuid
 from io import BytesIO
 from pathlib import Path as SyncPath
 from typing import Any
@@ -127,7 +128,7 @@ class LocalFileDatasetType(FileIngestableDatasetType):
                 "collectionName": {
                     "type": "string",
                     "title": "Collection Name",
-                    "description": "The name of the weaviate collection to ingest the data into",
+                    "description": "The name of the weaviate collection to ingest the data into. If not provided, a unique identifier will be auto-generated.",
                 },
                 "ingestFileTypeOptions": {
                     "type": "array",
@@ -178,7 +179,7 @@ class LocalFileDatasetType(FileIngestableDatasetType):
                     "default": [],
                 },
             },
-            "required": ["collectionName", "filePaths"],
+            "required": ["filePaths"],
         }
 
     def watched_paths(self) -> list[str]:
@@ -218,9 +219,9 @@ class LocalFileDatasetType(FileIngestableDatasetType):
 
         # TODO: Maybe use Pydantic model to validate configuration
 
-        # Check if required fields are present
-        if "collectionName" not in configuration:
-            raise ValueError("collectionName is required")
+        # Generate collectionName if not provided
+        if "collectionName" not in configuration or not configuration["collectionName"]:
+            configuration["collectionName"] = uuid.uuid4().hex
 
         # Validate collectionName,
         # it can only contain letters, numbers, and underscores (_), and spaces are not allowed.

--- a/frontend/src/api/types/index.ts
+++ b/frontend/src/api/types/index.ts
@@ -24,7 +24,7 @@ export interface CreateDatasetRequest {
   summary: string
   tags: string
   configuration: {
-    collectionName: string
+    collectionName?: string
     filePaths: FilePathItem[]
   }
 }

--- a/frontend/src/components/CreateDatasetDialogSimple.vue
+++ b/frontend/src/components/CreateDatasetDialogSimple.vue
@@ -262,12 +262,6 @@ const isFormValid = computed(() => {
   return formData.value.name.trim() !== '' && formData.value.selectedFiles.length > 0
 })
 
-// Utility function to generate collection name using UUID hex
-const generateCollectionName = (): string => {
-  // Generate a random UUID and return its hex representation without dashes
-  return crypto.randomUUID().replace(/-/g, '')
-}
-
 // Methods
 const getFileName = (path: string) => {
   return path.split('/').pop() || path
@@ -341,7 +335,6 @@ const handleCreate = async () => {
         summary: formData.value.summary.trim() || '',
         tags: formData.value.tags.join(','),
         configuration: {
-          collectionName: generateCollectionName(),
           filePaths: filePathsWithDescriptions,
         },
       }

--- a/frontend/src/composables/useDataEndpointCreation.ts
+++ b/frontend/src/composables/useDataEndpointCreation.ts
@@ -72,11 +72,6 @@ export function useDataEndpointCreation() {
   // Computed
   const isLoading = computed(() => isCreating.value)
 
-  // Helper functions
-  const generateCollectionName = (): string => {
-    return crypto.randomUUID().replace(/-/g, '')
-  }
-
   // Get provider configuration for model creation
   const getProviderConfig = (provider: string) => {
     switch (provider) {
@@ -148,7 +143,6 @@ export function useDataEndpointCreation() {
       summary: `Dataset for ${data.summary}`,
       tags: data.tags.join(','),
       configuration: {
-        collectionName: generateCollectionName(),
         filePaths: filePathsWithDescriptions,
       },
     }


### PR DESCRIPTION
## Summary

- Fixes "crypto.randomUUID is not a function" error for users accessing the app over plain HTTP
- Makes `collectionName` optional in the dataset creation API
- Backend now auto-generates a UUID if `collectionName` is not provided

## Problem
`crypto.randomUUID()` is a Web API that only works in secure contexts (HTTPS or localhost). Users accessing the app via HTTP on a local network (e.g., `http://192.168.x.x:8080`) would encounter this error when creating datasets.

## Solution
Move the UUID generation responsibility from the frontend to the backend, where it always works regardless of the client's security context.

## Test plan
- [x] Create a dataset over HTTPS - should work as before
- [x] Create a dataset over HTTP (e.g., via local network IP) - should no longer error