### PR TITLE
fix: persist ChromaDB collection name to prevent data loss on reload

### DIFF
--- a/backend/API_SPECIFICATION.md
+++ b/backend/API_SPECIFICATION.md
@@ -79,7 +79,7 @@ Request Payload
 {"role": "assistant", "content": "The capital of France is Paris."}
 {"role": "system", "content": "You are a helpful assistant."},
     ],
-    "similarity_threshold": 0.8,
+    "similarity_threshold": 0.65,
     "limit": 5,
     "include_metadata": True,
     "max_tokens": 100,

--- a/backend/syft_space/components/dataset_types/chromadb_local/chromadb_type.py
+++ b/backend/syft_space/components/dataset_types/chromadb_local/chromadb_type.py
@@ -11,7 +11,7 @@ from pathlib import Path as SyncPath
 from typing import Any
 
 from anyio import Path as AsyncPath
-from pydantic import BaseModel, Field, ValidationError, field_validator
+from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
 from syft_space.components.dataset_types.interfaces import (
     FileIngestableDatasetType,
@@ -37,7 +37,7 @@ except ImportError:
     enabled = False
 
 DEFAULT_HTTP_PORT = 8100
-DEFAULT_SIMILARITY_THRESHOLD = 0.5
+DEFAULT_SIMILARITY_THRESHOLD = 0.65
 
 DEFAULT_INGEST_FILE_TYPE_OPTIONS = [
     ".pdf",
@@ -64,11 +64,10 @@ class FilePathItem(BaseModel):
 class ChromaDBLocalConfiguration(BaseModel):
     """Configuration for ChromaDB local dataset type."""
 
-    collection_name: str = Field(
-        ...,
+    collection_name: str | None = Field(
+        default=None,
         alias="collectionName",
-        default_factory=lambda: f"Collection_{uuid.uuid4().hex[:8]}",
-        description="Name of the ChromaDB collection (alphanumeric and underscores only)",
+        description="Name of the ChromaDB collection (auto-generated if not provided)",
     )
     http_port: int = Field(
         default=DEFAULT_HTTP_PORT,
@@ -87,6 +86,19 @@ class ChromaDBLocalConfiguration(BaseModel):
     )
 
     model_config = {"populate_by_name": True}
+
+    @model_validator(mode="before")
+    @classmethod
+    def generate_collection_name_if_missing(cls, data: dict[str, Any]) -> dict[str, Any]:
+        """Auto-generate collection name if not provided."""
+        if isinstance(data, dict):
+            if "collectionName" not in data and "collection_name" not in data:
+                data = dict(data)  # Avoid mutating input dict
+                data["collectionName"] = uuid.uuid4().hex[:8]
+            elif data.get("collectionName") is None and data.get("collection_name") is None:
+                data = dict(data)
+                data["collectionName"] = uuid.uuid4().hex[:8]
+        return data
 
     @field_validator("collection_name")
     @classmethod
@@ -120,6 +132,9 @@ class LocalFSChromaDBDatasetType(FileIngestableDatasetType):
         """
         self.raw_config = config
         self.config = ChromaDBLocalConfiguration.model_validate(config)
+
+        if self.config.collection_name and "collectionName" not in self.raw_config:
+            self.raw_config["collectionName"] = self.config.collection_name
 
         # Lazy initialization (instance-level)
         self._converter = None
@@ -201,8 +216,12 @@ class LocalFSChromaDBDatasetType(FileIngestableDatasetType):
     async def validate_configuration(cls, configuration: dict[str, Any]) -> None:
         """Validate the configuration for the dataset type.
 
+        Note: This method intentionally mutates the configuration dict to persist
+        the auto-generated collection_name. This is necessary so the same name
+        is used across all instantiations from the stored config.
+
         Args:
-            configuration: Configuration dictionary to validate
+            configuration: Configuration dictionary to validate (may be mutated)
 
         Raises:
             ValueError: If configuration is invalid
@@ -211,6 +230,10 @@ class LocalFSChromaDBDatasetType(FileIngestableDatasetType):
             config = ChromaDBLocalConfiguration.model_validate(configuration)
         except ValidationError as e:
             raise ValueError(f"Invalid configuration: {e}") from e
+
+        # Persist generated collection_name back to config dict for storage
+        if config.collection_name and "collectionName" not in configuration:
+            configuration["collectionName"] = config.collection_name
 
         # Validate file paths exist
         for file_path_item in config.file_paths:

--- a/backend/syft_space/components/endpoints/handlers.py
+++ b/backend/syft_space/components/endpoints/handlers.py
@@ -48,6 +48,49 @@ from syft_space.components.shared.syfthub_client import SyftHubClient, SyftHubEr
 from syft_space.components.tenants.entities import Tenant
 
 
+def extract_user_query(content: str) -> str:
+    """Extract the real user query from aggregator's bundled message format.
+
+    The SyftHub aggregator bundles instructions, documents, and the user's question
+    into a single user message with this format:
+
+        CRITICAL RULES - YOU MUST FOLLOW THESE:
+        ...
+        <documents>...</documents>
+        ---
+        USER QUESTION:
+        {actual_query}
+        ---
+
+    This function extracts just the actual query. If the marker isn't found,
+    returns the original content (for direct clients not using aggregator).
+
+    Args:
+        content: The message content (possibly bundled)
+
+    Returns:
+        The extracted user query
+    """
+    # Look for aggregator's USER QUESTION marker
+    marker = "USER QUESTION:"
+    marker_pos = content.find(marker)
+
+    if marker_pos == -1:
+        # No marker found - return original content (direct client)
+        return content.strip()
+
+    # Extract everything after "USER QUESTION:\n"
+    query_start = marker_pos + len(marker)
+    query_part = content[query_start:]
+
+    # Remove leading/trailing whitespace and the trailing "---" delimiter
+    query_part = query_part.strip()
+    if query_part.endswith("---"):
+        query_part = query_part[:-3].strip()
+
+    return query_part
+
+
 class EndpointHandler:
     """Handler for endpoint business logic."""
 
@@ -311,9 +354,9 @@ class EndpointHandler:
 
         response_type = ResponseType(endpoint.response_type)
 
-        # Search dataset if needed
+        # Search dataset if needed (also needed for SUMMARY to provide context to LLM)
         if (
-            response_type in [ResponseType.RAW, ResponseType.BOTH]
+            response_type in [ResponseType.RAW, ResponseType.BOTH, ResponseType.SUMMARY]
             and endpoint.dataset_id
         ):
             references = await self._search_dataset(endpoint, request)
@@ -325,8 +368,9 @@ class EndpointHandler:
         ):
             summary = await self._chat_with_model(endpoint, request, references)
 
-        # Create response
-        query_response = QueryEndpointResponse(summary=summary, references=references)
+        # Create response (SUMMARY mode: don't return raw references, only summary)
+        response_references = references if response_type != ResponseType.SUMMARY else None
+        query_response = QueryEndpointResponse(summary=summary, references=response_references)
 
         # Update policy context with response
         policy_context.response = query_response.model_dump()
@@ -381,13 +425,22 @@ class EndpointHandler:
         # Create dataset instance
         dataset_instance = dataset_type_cls(dataset.configuration)
 
-        # Prepare query
+        # Prepare query - extract real user question from aggregator's bundled format
         if isinstance(request.messages, str):
-            query = request.messages
+            query = extract_user_query(request.messages)
         else:
-            # Use last user message as query
+            # Get last user message and extract real query
             user_messages = [m for m in request.messages if m.role == "user"]
-            query = user_messages[-1].content if user_messages else ""
+            if user_messages:
+                query = extract_user_query(user_messages[-1].content)
+            else:
+                query = ""
+
+        # Validate query is not empty
+        if not query.strip():
+            raise HTTPException(
+                status_code=400, detail="No valid user query found in messages"
+            )
 
         # Search with verified sender email
         ctx = Context(sender=request.sender_email)
@@ -466,17 +519,23 @@ class EndpointHandler:
                 ChatMessage(role=m.role, content=m.content) for m in request.messages
             ]
 
+        # Validate we have at least one message
+        if not messages:
+            raise HTTPException(
+                status_code=400, detail="No messages provided"
+            )
+
         # Add references to context if available
         if references and references.documents:
-            context_content = "\\n\\n".join(
+            context_content = "\n\n".join(
                 [
-                    f"[{doc.document_id}] {doc.content}"
+                    f"[{doc.metadata.get('file_name', doc.document_id)}] {doc.content}"
                     for doc in references.documents[:3]
                 ]
             )
             context_message = ChatMessage(
                 role="system",
-                content=f"Use the following context to answer:\\n{context_content}",
+                content=f"Use the following context to answer:\n{context_content}",
             )
             messages.insert(0, context_message)
 

--- a/backend/syft_space/components/endpoints/schemas.py
+++ b/backend/syft_space/components/endpoints/schemas.py
@@ -220,7 +220,7 @@ class QueryEndpointRequest(BaseModel):
         ..., description="Messages or conversation string"
     )
     similarity_threshold: float = Field(
-        default=0.8, ge=0.0, le=1.0, description="Similarity threshold for matching"
+        default=0.65, ge=0.0, le=1.0, description="Similarity threshold for matching"
     )
     limit: int = Field(
         default=5, ge=1, description="Maximum number of results to return"
@@ -257,7 +257,7 @@ class QueryEndpointRequest(BaseModel):
                 "messages": [
                     {"role": "user", "content": "What is the capital of France?"}
                 ],
-                "similarity_threshold": 0.8,
+                "similarity_threshold": 0.65,
                 "limit": 5,
                 "max_tokens": 100,
                 "temperature": 0.7,


### PR DESCRIPTION
## Bug

<img width="3898" height="2030" alt="image" src="https://github.com/user-attachments/assets/c53eed99-c078-4805-a665-907b937fc5ca" />

## After fix

<img width="847" height="840" alt="Screenshot 2026-02-06 at 15 17 54" src="https://github.com/user-attachments/assets/a0b9823d-0573-4d5a-8cd8-778575e323d7" />
<img width="812" height="850" alt="Screenshot 2026-02-06 at 15 34 45" src="https://github.com/user-attachments/assets/a0bd1bab-f9f0-4f3c-98fd-a0e7bd468e54" />


## Summary of changes

**ChromaDB Collection Name Persistence (Critical Fix)**: Previously, collection names were auto-generated on each instantiation but never persisted to the stored configuration. This meant every time an endpoint was loaded, it would generate a *new* collection name and lose access to all previously indexed documents. Users would upload files, see them indexed successfully, but queries would return nothing because the system was looking in an empty collection. The fix ensures the auto-generated collection name is written back to the config on first creation, so all subsequent loads use the same collection.

**Other improvements in this PR:**
- **Readable document citations**: LLM now cites `[recipes.pdf]` instead of cryptic hashes like `[6a15a23824a2c95db2b21bcc312ef635]`
- **Query extraction**: Properly extracts the user's actual question from the aggregator's bundled message format, improving vector search relevance
- **SUMMARY mode fix**: Endpoints with `ResponseType.SUMMARY` now actually search the dataset for context (was previously skipped)
- **Similarity threshold**: Lowered default from 0.8 to 0.65 to avoid filtering out relevant documents

## Files Changed

| File | Changes |
|------|---------|
| `chromadb_type.py` | Collection name persistence fix |
| `handlers.py` | Query extraction, file name citations, SUMMARY includes RAG |
| `schemas.py` | Default similarity threshold 0.65 |
| `API_SPECIFICATION.md` | Updated examples |
