### PR TITLE
OME-233 frontend: chat UX polish (no-models state, submit shortcut)

### DIFF
--- a/frontend/src/pages/ChatPage.vue
+++ b/frontend/src/pages/ChatPage.vue
@@ -10,6 +10,7 @@ import {
   ChevronRight,
   FileText,
   Loader2,
+  Sparkles,
 } from 'lucide-vue-next'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
@@ -23,13 +24,15 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
-import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { modelsApi } from '@/api/endpoints/models'
 import { datasetsApi } from '@/api/endpoints/datasets'
 import { useLocalChat, type ChatTurn } from '@/composables/useLocalChat'
+import { useNavigation } from '@/composables/useNavigation'
 import type { ModelListItem, DatasetListItem } from '@/api/types'
 
 const { turns, loading, error, modelId, datasetId, sendMessage, clearChat } = useLocalChat()
+const { goToModels } = useNavigation()
 
 const models = ref<ModelListItem[]>([])
 const datasets = ref<DatasetListItem[]>([])
@@ -39,7 +42,10 @@ const inputText = ref('')
 const messagesEndRef = ref<HTMLElement | null>(null)
 const expandedRefs = ref<Set<number>>(new Set())
 
-const canSend = computed(() => modelId.value && inputText.value.trim() && !loading.value)
+const hasNoModels = computed(() => !modelsLoading.value && models.value.length === 0)
+const canSubmit = computed(
+  () => inputText.value.trim().length > 0 && modelId.value != null && !loading.value,
+)
 
 onMounted(async () => {
   const [modelsList, datasetsList] = await Promise.all([
@@ -60,17 +66,22 @@ watch(
 )
 
 async function handleSend() {
-  if (!canSend.value) return
+  if (!canSubmit.value) return
   const text = inputText.value.trim()
   inputText.value = ''
   await sendMessage(text)
 }
 
+function isDialogOpen(): boolean {
+  return document.querySelector('[role="dialog"][data-state="open"]') !== null
+}
+
 function handleKeydown(e: KeyboardEvent) {
-  if (e.key === 'Enter' && !e.shiftKey) {
-    e.preventDefault()
-    handleSend()
-  }
+  if (e.key !== 'Enter' || e.shiftKey) return
+  if (!(e.ctrlKey || e.metaKey)) return
+  if (isDialogOpen()) return
+  e.preventDefault()
+  handleSend()
 }
 
 function toggleRefs(index: number) {
@@ -96,9 +107,26 @@ function isAssistant(turn: ChatTurn) {
     <!-- Messages Area -->
     <ScrollArea class="flex-1">
       <div class="max-w-3xl mx-auto px-6 py-6">
+        <!-- No Models Available State -->
+        <div
+          v-if="hasNoModels && turns.length === 0"
+          class="flex flex-col items-center justify-center py-24"
+        >
+          <Alert class="max-w-md">
+            <Sparkles class="h-4 w-4" />
+            <AlertTitle>No models available</AlertTitle>
+            <AlertDescription>
+              <p class="mb-3">
+                You need at least one model before you can test your resources in chat.
+              </p>
+              <Button size="sm" @click="goToModels"> Add a model </Button>
+            </AlertDescription>
+          </Alert>
+        </div>
+
         <!-- Empty State -->
         <div
-          v-if="turns.length === 0 && !loading"
+          v-else-if="turns.length === 0 && !loading"
           class="flex flex-col items-center justify-center py-24 text-center"
         >
           <MessageSquare class="h-12 w-12 text-muted-foreground/40 mb-6" />
@@ -250,13 +278,19 @@ function isAssistant(turn: ChatTurn) {
         <div class="flex gap-3">
           <Textarea
             v-model="inputText"
-            :placeholder="modelId ? 'Ask a question...' : 'Select a model to start chatting'"
+            :placeholder="
+              hasNoModels
+                ? 'Add a model to start chatting'
+                : modelId
+                  ? 'Ask a question...'
+                  : 'Select a model to start chatting'
+            "
             :disabled="!modelId"
             class="resize-none min-h-[44px] max-h-[120px]"
             rows="1"
             @keydown="handleKeydown"
           />
-          <Button :disabled="!canSend" class="shrink-0 self-end" @click="handleSend">
+          <Button :disabled="!canSubmit" class="shrink-0 self-end" @click="handleSend">
             <Send class="h-4 w-4" />
           </Button>
         </div>


### PR DESCRIPTION
## Summary

Harden `ChatPage.vue` for the `redesign_ux` merge into `main` (Linear OME-233, frontend half).

- Add a shadcn `Alert` "No models available" empty state with an **Add a model** CTA that routes to the Models page via `useNavigation().goToModels`.
- Add a Ctrl/Cmd+Enter submit shortcut on the textarea. Shift+Enter still inserts a newline; the handler bails out when a Reka UI dialog is open (`[role="dialog"][data-state="open"]`).
- Rename `canSend` to `canSubmit` matching the sub-issue spec, and ensure the submit button is disabled when the input is empty, no model is selected, or a request is in flight.

## Files changed

- `frontend/src/pages/ChatPage.vue` (only)

Stays clear of Units 1/2/3/5 (`useGoLive.ts`, `GoLivePage.vue`, policy types, backend chat, `AppSidebar.vue`).

## Test plan

- [x] `bun run format` (ChatPage.vue only — reverted unrelated reformats prettier wanted to apply to sibling pages)
- [x] `bun run lint` — oxlint + eslint clean
- [x] `bun run typecheck` — `vue-tsc --build` passes
- [ ] `bun run test:unit` — **pre-existing failure** on `redesign_ux`: `src/__tests__/App.spec.ts` crashes in `useSidebar.ts` with `localStorage.getItem is not a function` under jsdom. Verified this fails on the unmodified base branch, so it is not regressed by this PR and is out of scope for OME-233b. A component test for `canSubmit` was not added because the current test infrastructure cannot mount page components that transitively import `useSidebar`.

### Manual verification recipe

- With zero models configured: the No-models Alert should render and the "Add a model" button should navigate to `/models`.
- With models configured: pick a model, type text, press Ctrl+Enter (or Cmd+Enter on macOS) — message should send. Press Enter alone or Shift+Enter — should just insert text. Send button should be disabled until input + model are both set.

🤖 Generated with Claude Code