### PR TITLE
fix(sidebar): trustworthy resource search (OME-236)

### DIFF
--- a/frontend/src/components/AppSidebar.vue
+++ b/frontend/src/components/AppSidebar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
-import { useRouter, useRoute } from 'vue-router'
+import { useRouter, useRoute, type RouteLocationRaw } from 'vue-router'
+import { toast } from 'vue-sonner'
 import {
   LayoutDashboard,
   Database,
@@ -22,6 +23,7 @@ import { Input } from '@/components/ui/input'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { Separator } from '@/components/ui/separator'
 import { useSidebar } from '@/composables/useSidebar'
+import { useNavigation } from '@/composables/useNavigation'
 import { useInboxStore } from '@/stores/inbox'
 import { useUserStore } from '@/stores/user'
 import { useEndpointsStore } from '@/stores/endpoints'
@@ -33,6 +35,7 @@ import ThemeToggle from '@/components/ThemeToggle.vue'
 const router = useRouter()
 const route = useRoute()
 const { isCollapsed, toggle } = useSidebar()
+const { routes } = useNavigation()
 const inboxStore = useInboxStore()
 const userStore = useUserStore()
 const endpointsStore = useEndpointsStore()
@@ -41,65 +44,106 @@ const liveCount = computed(() => endpointsStore.endpoints.filter((e) => e.publis
 
 const searchQuery = ref('')
 const searchFocused = ref(false)
-const searchInputRef = ref<HTMLInputElement | null>(null)
+const highlightedIndex = ref(0)
+const SEARCH_RESULT_ID_PREFIX = 'sidebar-search-result-'
+const RESOURCE_CACHE_TTL_MS = 30_000
 
 interface SearchResult {
   name: string
+  summary: string
+  tags: string[]
   type: 'data-source' | 'model' | 'api'
   icon: typeof Database
-  route: { name: string; params?: Record<string, string> }
+  route: RouteLocationRaw
+}
+
+function parseTags(raw: string | string[] | undefined): string[] {
+  if (!raw) return []
+  if (Array.isArray(raw)) return raw.map((t) => t.trim()).filter(Boolean)
+  return raw
+    .split(',')
+    .map((t) => t.trim())
+    .filter(Boolean)
 }
 
 const allResources = ref<SearchResult[]>([])
-const resourcesLoaded = ref(false)
+const lastLoadedAt = ref(0)
+let inFlightLoad: Promise<void> | null = null
 
-async function loadResources() {
-  if (resourcesLoaded.value) return
-  try {
-    const [datasets, models] = await Promise.all([datasetsApi.list(), modelsApi.list()])
-    const results: SearchResult[] = []
-    for (const d of datasets) {
-      results.push({
-        name: d.name,
-        type: 'data-source',
-        icon: Database,
-        route: { name: 'dataset-detail', params: { name: d.name } },
-      })
+async function loadResources(force = false): Promise<void> {
+  if (inFlightLoad) return inFlightLoad
+  const isFresh = Date.now() - lastLoadedAt.value < RESOURCE_CACHE_TTL_MS
+  if (!force && lastLoadedAt.value > 0 && isFresh) return
+
+  inFlightLoad = (async () => {
+    try {
+      const [datasets, models] = await Promise.all([datasetsApi.list(), modelsApi.list()])
+      const results: SearchResult[] = []
+      for (const d of datasets) {
+        results.push({
+          name: d.name,
+          summary: d.summary ?? '',
+          tags: parseTags(d.tags),
+          type: 'data-source',
+          icon: Database,
+          route: routes.dataSourceDetail(d.name),
+        })
+      }
+      for (const m of models) {
+        results.push({
+          name: m.name,
+          summary: m.summary ?? '',
+          tags: parseTags(m.tags),
+          type: 'model',
+          icon: Brain,
+          route: routes.modelDetail(m.name),
+        })
+      }
+      for (const e of endpointsStore.endpoints) {
+        results.push({
+          name: e.name,
+          summary: e.summary ?? '',
+          tags: parseTags(e.tags),
+          type: 'api',
+          icon: Globe,
+          route: routes.liveDetail(e.slug),
+        })
+      }
+      allResources.value = results
+      lastLoadedAt.value = Date.now()
+    } catch (err) {
+      console.error('Failed to load sidebar resources for search:', err)
+      toast.error('Could not load resources')
+    } finally {
+      inFlightLoad = null
     }
-    for (const m of models) {
-      results.push({
-        name: m.name,
-        type: 'model',
-        icon: Brain,
-        route: { name: 'model-detail', params: { name: m.name } },
-      })
-    }
-    for (const e of endpointsStore.endpoints) {
-      results.push({
-        name: e.name,
-        type: 'api',
-        icon: Globe,
-        route: { name: 'endpoint-detail', params: { slug: e.slug } },
-      })
-    }
-    allResources.value = results
-    resourcesLoaded.value = true
-  } catch {
-    // silently fail — search just won't show results
-  }
+  })()
+
+  return inFlightLoad
 }
 
 const searchResults = computed(() => {
   const q = searchQuery.value.toLowerCase().trim()
   if (!q) return []
-  return allResources.value.filter((r) => r.name.toLowerCase().includes(q)).slice(0, 8)
+  return allResources.value
+    .filter((r) => {
+      if (r.name.toLowerCase().includes(q)) return true
+      if (r.summary.toLowerCase().includes(q)) return true
+      return r.tags.some((t) => t.toLowerCase().includes(q))
+    })
+    .slice(0, 8)
 })
 
 const showDropdown = computed(() => searchFocused.value && searchQuery.value.trim().length > 0)
 
+const activeDescendantId = computed(() => {
+  if (!showDropdown.value || searchResults.value.length === 0) return undefined
+  return `${SEARCH_RESULT_ID_PREFIX}${highlightedIndex.value}`
+})
+
 function handleSearchFocus() {
   searchFocused.value = true
-  loadResources()
+  void loadResources()
 }
 
 function selectResult(result: SearchResult) {
@@ -114,12 +158,38 @@ function handleSearchBlur() {
   }, 150)
 }
 
-watch(
-  () => route.path,
-  () => {
-    resourcesLoaded.value = false
-  },
-)
+function handleSearchKeydown(event: KeyboardEvent) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    searchQuery.value = ''
+    ;(event.target as HTMLInputElement | null)?.blur()
+    return
+  }
+  if (!showDropdown.value) return
+  const results = searchResults.value
+  if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    if (results.length === 0) return
+    highlightedIndex.value = Math.min(highlightedIndex.value + 1, results.length - 1)
+    return
+  }
+  if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    if (results.length === 0) return
+    highlightedIndex.value = Math.max(highlightedIndex.value - 1, 0)
+    return
+  }
+  if (event.key === 'Enter') {
+    const result = results[highlightedIndex.value]
+    if (!result) return
+    event.preventDefault()
+    selectResult(result)
+  }
+}
+
+watch(searchResults, () => {
+  highlightedIndex.value = 0
+})
 
 const routeMapping: Record<string, string[]> = {
   home: ['home'],
@@ -133,8 +203,8 @@ const routeMapping: Record<string, string[]> = {
 }
 
 const isActive = (navId: string) => {
-  const routes = routeMapping[navId]
-  return routes ? routes.includes(route.name as string) : false
+  const mapped = routeMapping[navId]
+  return mapped ? mapped.includes(route.name as string) : false
 }
 
 const navigateTo = (routeName: string) => {
@@ -229,26 +299,38 @@ const renderNavItem = (item: NavItem) => ({
           class="absolute left-2.5 top-1/2 -translate-y-1/2 h-3.5 w-3.5 text-muted-foreground pointer-events-none"
         />
         <Input
-          ref="searchInputRef"
           v-model="searchQuery"
           placeholder="Search resources..."
           class="h-8 pl-8 pr-3 text-sm bg-muted/50 border-transparent focus:border-border focus:bg-background"
+          role="combobox"
+          :aria-expanded="showDropdown"
+          aria-controls="sidebar-search-results"
+          aria-autocomplete="list"
+          :aria-activedescendant="activeDescendantId"
           @focus="handleSearchFocus"
           @blur="handleSearchBlur"
+          @keydown="handleSearchKeydown"
         />
       </div>
       <div
         v-if="showDropdown"
+        id="sidebar-search-results"
+        role="listbox"
         class="absolute left-3 right-3 top-full mt-1 bg-popover border border-border rounded-md shadow-md z-50 overflow-hidden"
       >
         <div v-if="searchResults.length === 0" class="px-3 py-2 text-xs text-muted-foreground">
           No results for "{{ searchQuery }}"
         </div>
         <button
-          v-for="result in searchResults"
+          v-for="(result, index) in searchResults"
+          :id="`sidebar-search-result-${index}`"
           :key="`${result.type}-${result.name}`"
-          class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground hover:bg-muted transition-colors text-left"
+          role="option"
+          :aria-selected="index === highlightedIndex"
+          class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-foreground transition-colors text-left"
+          :class="index === highlightedIndex ? 'bg-muted' : 'hover:bg-muted'"
           @mousedown.prevent="selectResult(result)"
+          @mousemove="highlightedIndex = index"
         >
           <component :is="result.icon" class="h-3.5 w-3.5 text-muted-foreground shrink-0" />
           <span class="truncate flex-1">{{ result.name }}</span>


### PR DESCRIPTION
## Summary

Hardens the sidebar resource search in `AppSidebar.vue` so failures surface, the filter is meaningful, and keyboard nav works.

- **Error surfacing**: silent `catch` replaced with `console.error` + `toast.error('Could not load resources')`. Search UI still renders on failure.
- **Filter coverage**: predicate now matches `name`, `summary`, and `tags`. `parseTags` accepts both comma-separated strings (datasets/models) and string arrays (endpoint store), trims, and drops empties.
- **Keyboard navigation**: `ArrowUp`/`ArrowDown` move `highlightedIndex` clamped to `[0, results.length - 1]`, `Enter` navigates the highlighted row, `Escape` clears the query and blurs. Highlight resets to 0 on any change to the filtered results. `role="combobox"` / `role="listbox"` / `aria-activedescendant` wired up for screen readers.
- **Cache freshness (30s TTL)**: chose a time-based TTL over window-focus or focus-always because it is the simplest option that (a) stops the `watch(route.path, ...)` stale-between-loads bug, (b) avoids refetching on every keystroke, and (c) doesn't add new event listeners. An in-flight `Promise` de-dupes concurrent loads.
- **Drive-by**: the old code passed `params: { name }` to the dataset/model detail routes, which expect `slug`. Switched to `useNavigation`'s `routes.dataSourceDetail` / `routes.modelDetail` / `routes.liveDetail` helpers which use the correct key.

Layout, Phase 1 nav sections, and all non-search code paths are untouched. Scope is limited to `frontend/src/components/AppSidebar.vue`.

## Test plan

- [x] `bun run format` (only AppSidebar.vue affected after reverting unrelated pre-existing prettier drift)
- [x] `bun run lint` — 0 warnings, 0 errors
- [x] `bun run typecheck` — clean
- [ ] `bun run test:unit` — **pre-existing failure** unrelated to this change: `src/__tests__/App.spec.ts` is a stale scaffold (asserts `"You did it!"`) that fails on `localStorage.getItem is not a function` at `useSidebar.ts:5` because the harness runs Node 25 which ships an experimental global `localStorage` stub that masks jsdom's. Reproduces on `redesign_ux` without this diff. Out of scope for OME-236.
- [ ] Manual: focus search, type, verify arrow keys / Enter / Escape
- [ ] Manual: kill the backend, focus search, verify toast appears and UI stays usable