### PR TITLE
feat(policies): implement PII filter policy end-to-end (OME-234)

### DIFF
--- a/backend/syft_space/components/policy_types/__init__.py
+++ b/backend/syft_space/components/policy_types/__init__.py
@@ -17,11 +17,13 @@ def register_builtin_types(registry: "PolicyTypeRegistry") -> None:
     # Import and register built-in policy types here as they're implemented
     from .access.access_type import EndpointAccessPolicy
     from .mpp_accounting.mpp_accounting_type import MppAccountingPolicy
+    from .pii_filter.pii_filter_type import PiiFilterType
     from .rate_limit.rate_limit_type import EndpointRateLimitPolicy
 
     registry.register_policy_type(EndpointRateLimitPolicy)
     registry.register_policy_type(EndpointAccessPolicy)
     registry.register_policy_type(MppAccountingPolicy)
+    registry.register_policy_type(PiiFilterType)
 
 
 __all__ = ["register_builtin_types"]

--- a/backend/syft_space/components/policy_types/pii_filter/__init__.py
+++ b/backend/syft_space/components/policy_types/pii_filter/__init__.py
@@ -1,0 +1,11 @@
+"""PII filter policy type."""
+
+from syft_space.components.policy_types.pii_filter.pii_filter_type import (
+    PiiFilterConfig,
+    PiiFilterType,
+)
+
+__all__ = [
+    "PiiFilterType",
+    "PiiFilterConfig",
+]

--- a/backend/syft_space/components/policy_types/pii_filter/pii_filter_type.py
+++ b/backend/syft_space/components/policy_types/pii_filter/pii_filter_type.py
@@ -1,0 +1,230 @@
+"""PII filter policy type implementation.
+
+Redacts common personally identifiable information (PII) from endpoint
+responses using regular expressions. Runs in the ``post_hook`` phase and
+mutates ``PolicyContext.response`` in place while preserving the JSON
+structure — only string leaves are touched.
+"""
+
+import re
+from typing import Any
+
+from pydantic import BaseModel, Field, field_validator
+
+from syft_space.components.policy_types.interfaces import (
+    BasePolicyType,
+    PolicyContext,
+)
+from syft_space.components.shared.utils import ConfigSchemaGenerator
+
+#: Categories of PII that this policy knows how to redact.
+SUPPORTED_CATEGORIES: tuple[str, ...] = (
+    "email",
+    "phone",
+    "ssn",
+    "credit_card",
+)
+
+#: Default replacement token if none is supplied in the config.
+DEFAULT_REPLACEMENT = "[REDACTED]"
+
+
+# Pattern order matters: more specific patterns (SSN) run before broader
+# ones (credit card) so they are not swallowed by overlapping matches.
+_CATEGORY_PATTERNS: dict[str, re.Pattern[str]] = {
+    "email": re.compile(r"[\w.+-]+@[\w-]+\.[\w.-]+"),
+    "ssn": re.compile(r"\b\d{3}-\d{2}-\d{4}\b"),
+    "phone": re.compile(
+        # International (+country code) or North American formats. Requires
+        # at least one separator to avoid matching arbitrary 10-digit runs
+        # that would better be classified as credit cards.
+        r"(?:\+\d{1,3}[\s.-]?)?\(\d{3}\)[\s.-]?\d{3}[\s.-]?\d{4}"
+        r"|(?:\+\d{1,3}[\s.-]?)?\d{3}[\s.-]\d{3}[\s.-]\d{4}"
+    ),
+    # 13–19 digit runs, optionally separated by single spaces or dashes.
+    "credit_card": re.compile(r"\b(?:\d[ -]?){12,18}\d\b"),
+}
+
+
+def _passes_luhn(digits: str) -> bool:
+    """Return True if a bare digit string passes the Luhn checksum."""
+    if not digits.isdigit() or not 13 <= len(digits) <= 19:
+        return False
+    total = 0
+    parity = len(digits) % 2
+    for i, ch in enumerate(digits):
+        d = int(ch)
+        if i % 2 == parity:
+            d *= 2
+            if d > 9:
+                d -= 9
+        total += d
+    return total % 10 == 0
+
+
+class PiiFilterConfig(BaseModel):
+    """Configuration schema for PII filter policy."""
+
+    categories: list[str] = Field(
+        default_factory=lambda: list(SUPPORTED_CATEGORIES),
+        description=(
+            "Categories of PII to redact. Supported values: "
+            f"{', '.join(SUPPORTED_CATEGORIES)}."
+        ),
+    )
+    replacement: str = Field(
+        default=DEFAULT_REPLACEMENT,
+        description="Token used to replace detected PII.",
+    )
+
+    @field_validator("categories")
+    @classmethod
+    def _validate_categories(cls, value: list[str]) -> list[str]:
+        """Reject unknown categories and de-duplicate the list."""
+        unknown = [c for c in value if c not in SUPPORTED_CATEGORIES]
+        if unknown:
+            raise ValueError(
+                "Unknown PII categories: "
+                f"{', '.join(unknown)}. "
+                f"Supported: {', '.join(SUPPORTED_CATEGORIES)}."
+            )
+        # Preserve order while removing duplicates.
+        seen: set[str] = set()
+        deduped: list[str] = []
+        for cat in value:
+            if cat not in seen:
+                seen.add(cat)
+                deduped.append(cat)
+        return deduped
+
+
+class PiiFilterType(BasePolicyType):
+    """Policy that redacts PII from endpoint responses.
+
+    Aggregation: UNION — every configured policy contributes its own
+    category set; the effective redaction set is the union across all
+    attached ``pii_filter`` policies. This means adding another policy
+    can only *add* redaction, never weaken it.
+
+    The policy is stateless and only mutates ``context.response``.
+    """
+
+    NAME = "pii_filter"
+
+    def __init__(self) -> None:
+        """Policy is stateless — no per-instance setup required."""
+        return None
+
+    @classmethod
+    def name(cls) -> str:
+        """Return the policy type name."""
+        return cls.NAME
+
+    @classmethod
+    def description(cls) -> str:
+        """Return a human description of the policy type."""
+        return (
+            "Redact common personally identifiable information (email, phone, "
+            "SSN, credit card) from endpoint responses before returning them "
+            "to the caller."
+        )
+
+    @classmethod
+    def icon(cls) -> str:
+        """Return the display icon for the policy type."""
+        return "🛡️"
+
+    @classmethod
+    def configuration_schema(cls) -> dict[str, Any]:
+        """Return the JSON schema describing this policy's configuration."""
+        return PiiFilterConfig.model_json_schema(schema_generator=ConfigSchemaGenerator)
+
+    async def pre_hook(
+        self, configs: list[dict[str, Any]], context: PolicyContext
+    ) -> PolicyContext:
+        """No pre-request work — PII redaction only runs on responses."""
+        return context
+
+    async def post_hook(
+        self, configs: list[dict[str, Any]], context: PolicyContext
+    ) -> PolicyContext:
+        """Redact configured PII categories from ``context.response``."""
+        if not configs or context.response is None:
+            return context
+
+        validated = [PiiFilterConfig(**c) for c in configs]
+
+        # Union the categories across all policies; use the first non-default
+        # replacement token if any is supplied, otherwise the default.
+        category_set: set[str] = set()
+        replacement = DEFAULT_REPLACEMENT
+        for cfg in validated:
+            category_set.update(cfg.categories)
+            if cfg.replacement and cfg.replacement != DEFAULT_REPLACEMENT:
+                replacement = cfg.replacement
+
+        if not category_set:
+            return context
+
+        patterns = [
+            (cat, _CATEGORY_PATTERNS[cat])
+            for cat in SUPPORTED_CATEGORIES
+            if cat in category_set
+        ]
+
+        context.response = self._redact(context.response, patterns, replacement)
+        return context
+
+    @classmethod
+    def enabled(cls) -> bool:
+        """PII filter is always available."""
+        return True
+
+    @classmethod
+    async def validate_config(cls, config: dict[str, Any]) -> dict[str, Any]:
+        """Validate and normalise a configuration dictionary."""
+        try:
+            validated = PiiFilterConfig(**config)
+            return validated.model_dump()
+        except Exception as e:
+            raise ValueError(f"Invalid pii_filter policy config: {e}") from e
+
+    def _redact(
+        self,
+        value: Any,
+        patterns: list[tuple[str, re.Pattern[str]]],
+        replacement: str,
+    ) -> Any:
+        """Recursively redact PII from ``value`` preserving JSON structure."""
+        if isinstance(value, dict):
+            return {k: self._redact(v, patterns, replacement) for k, v in value.items()}
+        if isinstance(value, list):
+            return [self._redact(item, patterns, replacement) for item in value]
+        if isinstance(value, str):
+            return self._redact_string(value, patterns, replacement)
+        return value
+
+    def _redact_string(
+        self,
+        text: str,
+        patterns: list[tuple[str, re.Pattern[str]]],
+        replacement: str,
+    ) -> str:
+        """Apply each configured category pattern to a single string leaf."""
+        for category, pattern in patterns:
+            if category == "credit_card":
+                text = pattern.sub(
+                    lambda m: self._redact_credit_card(m.group(0), replacement),
+                    text,
+                )
+            else:
+                text = pattern.sub(replacement, text)
+        return text
+
+    @staticmethod
+    def _redact_credit_card(match_text: str, replacement: str) -> str:
+        """Only redact credit-card-shaped digits that pass the Luhn check."""
+        digits = re.sub(r"[ -]", "", match_text)
+        if _passes_luhn(digits):
+            return replacement
+        return match_text

--- a/backend/syft_space/components/policy_types/pii_filter/tests/test_pii_filter.py
+++ b/backend/syft_space/components/policy_types/pii_filter/tests/test_pii_filter.py
@@ -1,0 +1,242 @@
+"""Tests for the PII filter policy type."""
+
+from __future__ import annotations
+
+import pytest
+
+from syft_space.components.policy_types.interfaces import PolicyContext
+from syft_space.components.policy_types.pii_filter.pii_filter_type import (
+    DEFAULT_REPLACEMENT,
+    PiiFilterConfig,
+    PiiFilterType,
+)
+
+
+def _ctx(response: dict | None) -> PolicyContext:
+    return PolicyContext(
+        endpoint_slug="test-endpoint",
+        sender_email="tester@example.com",
+        request={},
+        response=response,
+    )
+
+
+def _default_cfg() -> dict:
+    return PiiFilterConfig().model_dump()
+
+
+def _response(context: PolicyContext) -> dict:
+    """Return ``context.response`` and fail the test if it is ``None``."""
+    assert context.response is not None
+    return context.response
+
+
+@pytest.mark.asyncio
+async def test_post_hook_redacts_email_in_string_response() -> None:
+    policy = PiiFilterType()
+    context = _ctx({"message": "Contact us at support@example.com for help."})
+
+    result = await policy.post_hook([_default_cfg()], context)
+
+    assert DEFAULT_REPLACEMENT in _response(result)["message"]
+    assert "support@example.com" not in _response(result)["message"]
+
+
+@pytest.mark.asyncio
+async def test_post_hook_redacts_phone_numbers() -> None:
+    policy = PiiFilterType()
+    cases = [
+        "Call (555) 123-4567 tomorrow.",
+        "Phone: 555-123-4567",
+        "International: +1 555-123-4567",
+        "Dotted: 555.123.4567",
+    ]
+
+    for sample in cases:
+        context = _ctx({"msg": sample})
+        result = await policy.post_hook([_default_cfg()], context)
+        assert DEFAULT_REPLACEMENT in _response(result)["msg"], sample
+        assert "123-4567" not in _response(result)["msg"], sample
+        assert "123.4567" not in _response(result)["msg"], sample
+
+
+@pytest.mark.asyncio
+async def test_post_hook_redacts_ssn() -> None:
+    policy = PiiFilterType()
+    context = _ctx({"msg": "SSN on file: 123-45-6789."})
+
+    result = await policy.post_hook([_default_cfg()], context)
+
+    assert "123-45-6789" not in _response(result)["msg"]
+    assert DEFAULT_REPLACEMENT in _response(result)["msg"]
+
+
+@pytest.mark.asyncio
+async def test_post_hook_redacts_credit_card_when_luhn_valid() -> None:
+    policy = PiiFilterType()
+    # 4111 1111 1111 1111 is the canonical Visa test number and passes Luhn.
+    context = _ctx({"msg": "Card: 4111 1111 1111 1111 expires soon."})
+
+    result = await policy.post_hook([_default_cfg()], context)
+
+    assert "4111 1111 1111 1111" not in _response(result)["msg"]
+    assert DEFAULT_REPLACEMENT in _response(result)["msg"]
+
+
+@pytest.mark.asyncio
+async def test_post_hook_does_not_redact_non_luhn_digit_runs() -> None:
+    policy = PiiFilterType()
+    # 16 digits but fails Luhn — should NOT be redacted as a credit card.
+    context = _ctx({"msg": "Order number 1234567812345678 shipped."})
+
+    result = await policy.post_hook([_default_cfg()], context)
+
+    assert "1234567812345678" in _response(result)["msg"]
+
+
+@pytest.mark.asyncio
+async def test_post_hook_recurses_into_nested_dicts_and_lists() -> None:
+    policy = PiiFilterType()
+    response = {
+        "user": {
+            "email": "jane@corp.example",
+            "contacts": [
+                "other@corp.example",
+                {"phone": "555-867-5309"},
+            ],
+        },
+        "status": "ok",
+    }
+    context = _ctx(response)
+
+    result = await policy.post_hook([_default_cfg()], context)
+
+    redacted = _response(result)
+    assert redacted["user"]["email"] == DEFAULT_REPLACEMENT
+    assert redacted["user"]["contacts"][0] == DEFAULT_REPLACEMENT
+    assert redacted["user"]["contacts"][1]["phone"] == DEFAULT_REPLACEMENT
+    assert redacted["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_post_hook_leaves_non_pii_text_untouched() -> None:
+    policy = PiiFilterType()
+    response = {
+        "title": "Weather report",
+        "body": "It will be sunny with a high of 72 and a low of 55.",
+    }
+    context = _ctx(response)
+
+    result = await policy.post_hook([_default_cfg()], context)
+
+    assert result.response == response
+
+
+@pytest.mark.asyncio
+async def test_post_hook_leaves_non_string_values_untouched() -> None:
+    policy = PiiFilterType()
+    response = {
+        "count": 42,
+        "ratio": 3.14,
+        "is_active": True,
+        "missing": None,
+        "tags": [1, 2, 3],
+    }
+    context = _ctx(response)
+
+    result = await policy.post_hook([_default_cfg()], context)
+
+    assert result.response == response
+
+
+@pytest.mark.asyncio
+async def test_post_hook_honours_custom_replacement_token() -> None:
+    policy = PiiFilterType()
+    cfg = PiiFilterConfig(replacement="<PII>").model_dump()
+    context = _ctx({"msg": "Email alice@example.com please"})
+
+    result = await policy.post_hook([cfg], context)
+
+    assert "<PII>" in _response(result)["msg"]
+    assert "alice@example.com" not in _response(result)["msg"]
+
+
+@pytest.mark.asyncio
+async def test_post_hook_only_redacts_enabled_categories() -> None:
+    policy = PiiFilterType()
+    cfg = PiiFilterConfig(categories=["email"]).model_dump()
+    context = _ctx({"msg": "Email bob@example.com and phone 555-123-4567"})
+
+    result = await policy.post_hook([cfg], context)
+
+    assert "bob@example.com" not in _response(result)["msg"]
+    assert "555-123-4567" in _response(result)["msg"]
+
+
+@pytest.mark.asyncio
+async def test_post_hook_with_no_configs_is_noop() -> None:
+    policy = PiiFilterType()
+    response = {"email": "test@example.com"}
+    context = _ctx(response)
+
+    result = await policy.post_hook([], context)
+
+    assert result.response == {"email": "test@example.com"}
+
+
+@pytest.mark.asyncio
+async def test_post_hook_with_none_response_is_noop() -> None:
+    policy = PiiFilterType()
+    context = _ctx(None)
+
+    result = await policy.post_hook([_default_cfg()], context)
+
+    assert result.response is None
+
+
+@pytest.mark.asyncio
+async def test_pre_hook_is_passthrough() -> None:
+    policy = PiiFilterType()
+    response = {"email": "test@example.com"}
+    context = _ctx(response)
+
+    result = await policy.pre_hook([_default_cfg()], context)
+
+    assert result is context
+    # pre_hook must not touch the response
+    assert result.response == {"email": "test@example.com"}
+
+
+@pytest.mark.asyncio
+async def test_validate_config_rejects_unknown_category() -> None:
+    with pytest.raises(ValueError, match="Unknown PII categories"):
+        await PiiFilterType.validate_config({"categories": ["dob"]})
+
+
+@pytest.mark.asyncio
+async def test_validate_config_accepts_known_categories() -> None:
+    cfg = await PiiFilterType.validate_config(
+        {"categories": ["email", "phone"], "replacement": "<X>"}
+    )
+
+    assert cfg["categories"] == ["email", "phone"]
+    assert cfg["replacement"] == "<X>"
+
+
+@pytest.mark.asyncio
+async def test_validate_config_deduplicates_categories() -> None:
+    cfg = await PiiFilterType.validate_config(
+        {"categories": ["email", "email", "phone"]}
+    )
+
+    assert cfg["categories"] == ["email", "phone"]
+
+
+def test_metadata_accessors() -> None:
+    assert PiiFilterType.name() == "pii_filter"
+    assert "personally identifiable information" in PiiFilterType.description()
+    assert PiiFilterType.icon()
+    schema = PiiFilterType.configuration_schema()
+    assert "properties" in schema
+    assert "categories" in schema["properties"]
+    assert "replacement" in schema["properties"]

--- a/frontend/src/components/PolicyFormDialog.vue
+++ b/frontend/src/components/PolicyFormDialog.vue
@@ -12,7 +12,9 @@
               ? 'access control'
               : policyType === 'rate_limit'
                 ? 'usage limit'
-                : 'pricing'
+                : policyType === 'pricing'
+                  ? 'pricing'
+                  : 'PII filter'
           }}
           policy for this endpoint.
         </DialogDescription>
@@ -90,8 +92,8 @@
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                    <SelectItem value="per user">Per User</SelectItem>
-                    <SelectItem value="global">Per Full API</SelectItem>
+                  <SelectItem value="per user">Per User</SelectItem>
+                  <SelectItem value="global">Per Full API</SelectItem>
                 </SelectContent>
               </Select>
             </div>
@@ -155,6 +157,46 @@
             </div>
           </div>
         </div>
+
+        <!-- PII Filter Policy Form -->
+        <div v-if="policyType === 'pii_filter'" class="space-y-4">
+          <div class="space-y-2">
+            <Label class="body-sm text-muted-foreground font-medium">Categories to redact</Label>
+            <div class="grid grid-cols-2 gap-2">
+              <label
+                v-for="category in PII_FILTER_CATEGORIES"
+                :key="category"
+                class="flex items-center gap-2 rounded-lg border border-border bg-card px-3 py-2"
+              >
+                <input
+                  type="checkbox"
+                  :checked="piiFilterForm.categories.includes(category)"
+                  @change="togglePiiCategory(category)"
+                />
+                <span class="body-sm capitalize">{{ category.replace('_', ' ') }}</span>
+              </label>
+            </div>
+            <p class="text-xs text-muted-foreground">
+              Matched values in endpoint responses are replaced with a placeholder token.
+            </p>
+          </div>
+          <div class="space-y-1">
+            <Label class="body-sm text-muted-foreground font-medium">Replacement token</Label>
+            <Input
+              v-model="piiFilterForm.replacement"
+              placeholder="[REDACTED]"
+              class="h-9 rounded-lg border-border bg-card body-sm"
+            />
+          </div>
+          <div class="space-y-1">
+            <Label class="body-sm text-muted-foreground font-medium">Note</Label>
+            <Input
+              v-model="piiFilterForm.note"
+              placeholder="Optional description"
+              class="h-9 rounded-lg border-border bg-card body-sm"
+            />
+          </div>
+        </div>
       </div>
 
       <DialogFooter>
@@ -195,12 +237,17 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { usePolicyCreation } from '@/composables/usePolicyCreation'
-import { getPolicyTypeLabel } from '@/config/policyTypes'
-import type { PolicyTypeId } from '@/config/policyTypes'
+import {
+  getPolicyTypeLabel,
+  PII_FILTER_CATEGORIES,
+  DEFAULT_PII_FILTER_CONFIG,
+} from '@/config/policyTypes'
+import type { PolicyTypeId, PiiFilterCategory } from '@/config/policyTypes'
 import type {
   AuthorizationFormData,
   RateLimitFormData,
   PricingFormData,
+  PiiFilterFormData,
 } from '@/composables/usePolicyCreation'
 
 const props = defineProps<{
@@ -240,6 +287,21 @@ const pricingForm = ref<PricingFormData>({
   note: '',
 })
 
+const piiFilterForm = ref<PiiFilterFormData>({
+  categories: [...DEFAULT_PII_FILTER_CONFIG.categories],
+  replacement: DEFAULT_PII_FILTER_CONFIG.replacement,
+  note: '',
+})
+
+const togglePiiCategory = (category: PiiFilterCategory) => {
+  const idx = piiFilterForm.value.categories.indexOf(category)
+  if (idx >= 0) {
+    piiFilterForm.value.categories.splice(idx, 1)
+  } else {
+    piiFilterForm.value.categories.push(category)
+  }
+}
+
 // Get current form data based on policy type
 const getCurrentFormData = () => {
   switch (props.policyType) {
@@ -249,6 +311,8 @@ const getCurrentFormData = () => {
       return rateLimiterForm.value
     case 'pricing':
       return pricingForm.value
+    case 'pii_filter':
+      return piiFilterForm.value
     default:
       return null
   }
@@ -271,6 +335,13 @@ const resetForm = (policyType: PolicyTypeId) => {
       break
     case 'pricing':
       pricingForm.value = { price: '', userType: 'all', users: '', note: '' }
+      break
+    case 'pii_filter':
+      piiFilterForm.value = {
+        categories: [...DEFAULT_PII_FILTER_CONFIG.categories],
+        replacement: DEFAULT_PII_FILTER_CONFIG.replacement,
+        note: '',
+      }
       break
   }
 }
@@ -301,6 +372,19 @@ const loadInitialData = (policyType: PolicyTypeId, data: Record<string, unknown>
         note: (data.note as string) || '',
       }
       break
+    case 'pii_filter': {
+      const rawCategories = Array.isArray(data.categories)
+        ? (data.categories as string[]).filter((c): c is PiiFilterCategory =>
+            (PII_FILTER_CATEGORIES as readonly string[]).includes(c),
+          )
+        : [...DEFAULT_PII_FILTER_CONFIG.categories]
+      piiFilterForm.value = {
+        categories: rawCategories,
+        replacement: (data.replacement as string) || DEFAULT_PII_FILTER_CONFIG.replacement,
+        note: (data.note as string) || '',
+      }
+      break
+    }
   }
 }
 

--- a/frontend/src/composables/useGoLive.ts
+++ b/frontend/src/composables/useGoLive.ts
@@ -7,6 +7,7 @@ import { endpointsApi } from '@/api/endpoints/endpoints'
 import { policiesApi } from '@/api/policies/policies'
 import { getProviderBaseUrl } from '@/config/providers'
 import { usePolicyCreation } from './usePolicyCreation'
+import { DEFAULT_PII_FILTER_CONFIG } from '@/config/policyTypes'
 import type { PolicyRulesRecord } from '@/config/policyTypes'
 import type {
   CreateDatasetRequest,
@@ -43,6 +44,7 @@ export interface GoLiveData {
   systemPrompt: string
 
   policyRules: PolicyRulesRecord
+  piiFilterEnabled: boolean
 
   name: string
   summary: string
@@ -174,6 +176,19 @@ export function useGoLive() {
 
   const createPolicies = async (data: GoLiveData, endpointId: string): Promise<void> => {
     const policyRequests = transformPolicyRules(data.policyRules, data.name)
+
+    if (data.piiFilterEnabled) {
+      policyRequests.push({
+        name: `PII Filter for ${data.name}`,
+        policy_type: 'pii_filter',
+        configuration: {
+          categories: [...DEFAULT_PII_FILTER_CONFIG.categories],
+          replacement: DEFAULT_PII_FILTER_CONFIG.replacement,
+        },
+        endpoint_id: '',
+      })
+    }
+
     if (policyRequests.length === 0) return
 
     creationStep.value = 'Applying access rules...'

--- a/frontend/src/composables/usePolicyCreation.ts
+++ b/frontend/src/composables/usePolicyCreation.ts
@@ -1,12 +1,18 @@
 import { ref } from 'vue'
 import { policiesApi } from '@/api/policies/policies'
 import { useUserStore } from '@/stores/user'
+import {
+  DEFAULT_PII_FILTER_CONFIG,
+  PII_FILTER_CATEGORIES,
+  type PiiFilterCategory,
+} from '@/config/policyTypes'
 import type { CreatePolicyRequest } from '@/api/types'
 
 export interface PolicyRules {
   access: Array<{ id: string; config: Record<string, unknown> }>
   rate_limit: Array<{ id: string; config: Record<string, unknown> }>
   pricing: Array<{ id: string; config: Record<string, unknown> }>
+  pii_filter?: Array<{ id: string; config: Record<string, unknown> }>
 }
 
 export interface AuthorizationFormData {
@@ -29,7 +35,17 @@ export interface PricingFormData {
   note: string
 }
 
-export type PolicyFormData = AuthorizationFormData | RateLimitFormData | PricingFormData
+export interface PiiFilterFormData {
+  categories: PiiFilterCategory[]
+  replacement: string
+  note: string
+}
+
+export type PolicyFormData =
+  | AuthorizationFormData
+  | RateLimitFormData
+  | PricingFormData
+  | PiiFilterFormData
 
 export function usePolicyCreation() {
   const isCreating = ref(false)
@@ -41,6 +57,7 @@ export function usePolicyCreation() {
       access: 'Authorization',
       rate_limit: 'Rate Limiter',
       pricing: 'Pricing',
+      pii_filter: 'PII Filter',
     }
     return displayNames[policyType as keyof typeof displayNames] || policyType
   }
@@ -60,6 +77,27 @@ export function usePolicyCreation() {
       .split(',')
       .map((u) => u.trim())
       .filter((u) => u.length > 0)
+  }
+
+  // Helper function to build a PII filter configuration from raw input.
+  const createPiiFilterConfiguration = (
+    rawCategories: unknown,
+    rawReplacement: unknown,
+  ): Record<string, unknown> => {
+    const categories = Array.isArray(rawCategories)
+      ? (rawCategories as unknown[]).filter((c): c is PiiFilterCategory =>
+          (PII_FILTER_CATEGORIES as readonly string[]).includes(c as string),
+        )
+      : []
+    const replacement =
+      typeof rawReplacement === 'string' && rawReplacement.length > 0
+        ? rawReplacement
+        : DEFAULT_PII_FILTER_CONFIG.replacement
+
+    return {
+      categories: categories.length > 0 ? categories : [...DEFAULT_PII_FILTER_CONFIG.categories],
+      replacement,
+    }
   }
 
   // Helper function to create pricing configuration
@@ -182,9 +220,28 @@ export function usePolicyCreation() {
     return await policiesApi.create(request)
   }
 
+  const createPiiFilterPolicy = async (
+    formData: PiiFilterFormData,
+    endpointId: string,
+    endpointName: string,
+    ruleIndex: number = 1,
+  ) => {
+    const policyName = generatePolicyName('pii_filter', formData, endpointName, ruleIndex)
+    const configuration = createPiiFilterConfiguration(formData.categories, formData.replacement)
+
+    const request: CreatePolicyRequest = {
+      name: policyName,
+      policy_type: 'pii_filter',
+      configuration,
+      endpoint_id: endpointId,
+    }
+
+    return await policiesApi.create(request)
+  }
+
   // Generic policy creation method that routes to specific handlers
   const createPolicy = async (
-    policyType: 'access' | 'rate_limit' | 'pricing',
+    policyType: 'access' | 'rate_limit' | 'pricing' | 'pii_filter',
     formData: PolicyFormData,
     endpointId: string,
     endpointName: string,
@@ -220,6 +277,14 @@ export function usePolicyCreation() {
             ruleIndex,
           )
           break
+        case 'pii_filter':
+          result = await createPiiFilterPolicy(
+            formData as PiiFilterFormData,
+            endpointId,
+            endpointName,
+            ruleIndex,
+          )
+          break
         default:
           throw new Error(`Unsupported policy type: ${policyType}`)
       }
@@ -241,8 +306,8 @@ export function usePolicyCreation() {
   ): CreatePolicyRequest[] => {
     const policyRequests: CreatePolicyRequest[] = []
 
-    // Only process implemented policy types (access, rate_limit, pricing)
-    const implementedPolicies = ['access', 'rate_limit', 'pricing']
+    // Only process implemented policy types
+    const implementedPolicies = ['access', 'rate_limit', 'pricing', 'pii_filter']
 
     Object.entries(policyRules).forEach(([policyType, rules]) => {
       if (!implementedPolicies.includes(policyType)) {
@@ -303,6 +368,11 @@ export function usePolicyCreation() {
           const users = rule.config.users as string
 
           configuration = createPricingConfiguration(price, userType, users)
+        } else if (policyType === 'pii_filter') {
+          configuration = createPiiFilterConfiguration(
+            rule.config.categories,
+            rule.config.replacement,
+          )
         } else {
           // Fallback for other policy types
           configuration = rule.config
@@ -348,6 +418,10 @@ export function usePolicyCreation() {
     return !isNaN(price) && price >= 0
   }
 
+  const validatePiiFilterForm = (formData: PiiFilterFormData): boolean => {
+    return Array.isArray(formData.categories) && formData.categories.length > 0
+  }
+
   const validatePolicyForm = (policyType: string, formData: PolicyFormData): boolean => {
     switch (policyType) {
       case 'access':
@@ -356,6 +430,8 @@ export function usePolicyCreation() {
         return validateRateLimitForm(formData as RateLimitFormData)
       case 'pricing':
         return validatePricingForm(formData as PricingFormData)
+      case 'pii_filter':
+        return validatePiiFilterForm(formData as PiiFilterFormData)
       default:
         return false
     }
@@ -377,11 +453,13 @@ export function usePolicyCreation() {
     createAuthorizationPolicy,
     createRateLimitPolicy,
     createPricingPolicy,
+    createPiiFilterPolicy,
     transformPolicyRules,
     validatePolicyForm,
     validateAuthorizationForm,
     validateRateLimitForm,
     validatePricingForm,
+    validatePiiFilterForm,
     processUserList,
     generatePolicyName,
     reset,

--- a/frontend/src/config/policyTypes.ts
+++ b/frontend/src/config/policyTypes.ts
@@ -1,11 +1,19 @@
 import { Shield, Gauge, DollarSign } from 'lucide-vue-next'
 import type { Component } from 'vue'
 
-export type PolicyTypeId = 'access' | 'rate_limit' | 'pricing'
+export type PolicyTypeId = 'access' | 'rate_limit' | 'pricing' | 'pii_filter'
+
+export const PII_FILTER_CATEGORIES = ['email', 'phone', 'ssn', 'credit_card'] as const
+export type PiiFilterCategory = (typeof PII_FILTER_CATEGORIES)[number]
+
+export const DEFAULT_PII_FILTER_CONFIG = {
+  categories: [...PII_FILTER_CATEGORIES] as PiiFilterCategory[],
+  replacement: '[REDACTED]',
+}
 
 export interface PolicyConfig {
   id: string
-  [key: string]: string | number
+  [key: string]: string | number | string[] | undefined
 }
 
 export interface PolicyRule {
@@ -60,6 +68,8 @@ export const getPolicyTypeLabel = (type: string): string => {
       return 'Usage Limits'
     case 'pricing':
       return 'Pricing'
+    case 'pii_filter':
+      return 'PII Filter'
     default:
       return 'Policy'
   }
@@ -69,6 +79,7 @@ export const createEmptyPolicyRules = (): PolicyRulesRecord => ({
   access: [],
   rate_limit: [],
   pricing: [],
+  pii_filter: [],
 })
 
 export const generateRuleId = (): string => {
@@ -139,6 +150,14 @@ export const getRuleSummary = (policyId: PolicyTypeId, config: PolicyConfig): st
           return `$${formattedPrice} per query for ${userList.join(', ')}`
         }
       }
+
+    case 'pii_filter': {
+      const categories = Array.isArray((config as unknown as { categories?: unknown }).categories)
+        ? ((config as unknown as { categories: string[] }).categories as string[])
+        : [...PII_FILTER_CATEGORIES]
+      if (categories.length === 0) return 'PII filter configured (no categories)'
+      return `Redact ${categories.join(', ')} from responses`
+    }
 
     default:
       return 'Rule configured'

--- a/frontend/src/pages/GoLivePage.vue
+++ b/frontend/src/pages/GoLivePage.vue
@@ -230,7 +230,7 @@ watch(aiModelId, (id) => {
   })
 })
 
-// PII Filter (UI-only, no backend support yet)
+// PII Filter toggle — emits a `pii_filter` policy on publish.
 const piiFilterEnabled = ref(false)
 
 // Multi-rule policy state
@@ -504,6 +504,7 @@ const buildGoLiveData = (): GoLiveData => ({
   aiModelId: hasModel.value ? selectedModelId.value : aiModelId.value,
   systemPrompt: systemPrompt.value.trim(),
   policyRules: policyRules.value,
+  piiFilterEnabled: piiFilterEnabled.value,
   name: name.value.trim(),
   summary: summary.value.trim(),
   description: description.value.trim(),
@@ -902,9 +903,7 @@ const handleOverwriteConfirm = async () => {
                 <div
                   class="flex items-start justify-between gap-4 p-4 rounded-lg border transition-all"
                   :class="
-                    piiFilterEnabled
-                      ? 'border-primary/30 bg-primary/5'
-                      : 'border-border bg-card'
+                    piiFilterEnabled ? 'border-primary/30 bg-primary/5' : 'border-border bg-card'
                   "
                 >
                   <div class="flex items-start gap-3 flex-1 min-w-0">


### PR DESCRIPTION
## Summary

Implements the OME-234 PII filter policy end-to-end, wiring the previously dead "PII Filter" toggle in the publish wizard to a real backend policy that redacts common PII from endpoint responses.

### Backend
- New `pii_filter` policy type under `backend/syft_space/components/policy_types/pii_filter/`, mirroring the structure of `access/`.
- Redacts email, phone, SSN, and credit card strings from `PolicyContext.response` in the `post_hook` phase using regex only — no NLP dependencies.
- Credit card matches are validated with a Luhn checksum so arbitrary 13–19 digit runs are left alone.
- JSON structure is preserved: recurses into dicts/lists, only string leaves are mutated; non-string leaves untouched.
- Aggregation across multiple configured policies is a UNION of categories — adding a policy can only add redaction.
- Registered in `register_builtin_types` alongside the existing policy types.
- 17 unit tests cover all categories, Luhn edge cases, recursion, custom replacement tokens, category filtering, noop cases, and config validation.

### Frontend
- `useGoLive` now appends a `pii_filter` `CreatePolicyRequest` (with default categories and `[REDACTED]` replacement) when `piiFilterEnabled` is true at publish time.
- `GoLivePage` passes the existing toggle state through `buildGoLiveData`.
- `usePolicyCreation` gains `PiiFilterFormData`, `createPiiFilterPolicy`, `validatePiiFilterForm`, and a shared `createPiiFilterConfiguration` helper used by both the single-create and batch-transform paths.
- `PolicyFormDialog` gains a PII filter branch (category checkboxes + replacement token input) so future rule-level configuration works.
- `policyTypes.ts` adds the `pii_filter` id, label, summary formatter, and default config constants.

## Test plan

- [x] `pytest backend/syft_space/components/policy_types/pii_filter/tests/` — 17/17 pass
- [x] `ruff check` on new backend files — clean
- [x] `mypy` on new backend files — no new errors
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean
- [ ] Manual: toggle PII Filter on in the publish wizard, publish an endpoint, call it, verify response PII is replaced with `[REDACTED]`