### PR TITLE
fix(marketplaces): support SyftHub email-verification OTP flow

### DIFF
--- a/backend/syft_space/components/marketplaces/handlers.py
+++ b/backend/syft_space/components/marketplaces/handlers.py
@@ -3,16 +3,24 @@
 from uuid import UUID
 
 from fastapi import HTTPException
+from fastapi.responses import JSONResponse
 
 from syft_space.components.marketplaces.entities import Marketplace
 from syft_space.components.marketplaces.repository import MarketplaceRepository
 from syft_space.components.marketplaces.schemas import (
+    EMAIL_VERIFICATION_REQUIRED_CODE,
     ConnectMarketplaceRequest,
     MarketplaceListItem,
     MarketplaceResponse,
     RegisterMarketplaceRequest,
+    ResendMarketplaceOTPRequest,
+    VerifyMarketplaceOTPRequest,
 )
-from syft_space.components.shared.syfthub_client import SyftHubClient, SyftHubError
+from syft_space.components.shared.syfthub_client import (
+    SyftHubClient,
+    SyftHubError,
+    UserResponse,
+)
 from syft_space.components.tenants.entities import Tenant
 from syft_space.config import app_settings
 
@@ -30,57 +38,118 @@ class MarketplaceHandler:
 
     async def register_marketplace(
         self, request: RegisterMarketplaceRequest, tenant: Tenant
-    ) -> MarketplaceResponse:
+    ) -> MarketplaceResponse | JSONResponse:
         """Register a new marketplace by creating a new SyftHub account.
 
-        Args:
-            request: Marketplace registration request
-            tenant: Tenant context
-
-        Returns:
-            Created marketplace
+        Returns a 201 MarketplaceResponse on success. When SyftHub requires
+        email verification, returns a 202 JSON body with code
+        ``EMAIL_VERIFICATION_REQUIRED`` so the client can collect the OTP
+        and call ``/verify-otp`` to finish setup.
         """
         async with SyftHubClient(str(request.url)) as syfthub_client:
             try:
-                user_profile = await syfthub_client.register(
+                register_response = await syfthub_client.register(
                     username=request.username,
                     email=request.email,
                     full_name=request.name,
                     password=request.password,
                 )
 
-                # Login to get authenticated client for subsequent calls
-                await syfthub_client.login(request.email, request.password)
-
-                # If public URL is set, update the domain
-                if app_settings.public_url:
-                    await syfthub_client.update_profile(
-                        domain=str(app_settings.public_url)
+                if register_response.requires_email_verification:
+                    return JSONResponse(
+                        status_code=202,
+                        content={
+                            "code": EMAIL_VERIFICATION_REQUIRED_CODE,
+                            "message": (
+                                "Account created. Enter the verification code "
+                                "sent to your email to finish setup."
+                            ),
+                            "email": request.email,
+                            "url": str(request.url),
+                        },
                     )
 
+                await syfthub_client.login(request.email, request.password)
+                await self._sync_public_url(syfthub_client)
             except SyftHubError as e:
                 raise e.to_http_exception() from e
 
-        # Check if the marketplace should be set as default
-        should_be_default = app_settings.default_marketplace_url == request.url
-
-        # Create marketplace entity
-        marketplace = Marketplace(
-            tenant_id=tenant.id,
-            name=user_profile.user.full_name,
-            username=user_profile.user.username,
+        return await self._persist_marketplace_after_signup(
+            tenant=tenant,
             url=str(request.url),
-            email=user_profile.user.email,
+            user=register_response.user,
             password=request.password,
-            is_default=False,
-            is_active=True,
         )
 
-        # Save to database
-        marketplace = await self.repository.create(marketplace)
+    async def verify_marketplace_otp(
+        self, request: VerifyMarketplaceOTPRequest, tenant: Tenant
+    ) -> MarketplaceResponse:
+        """Complete a pending registration by verifying the OTP, then persist."""
+        async with SyftHubClient(str(request.url)) as syfthub_client:
+            try:
+                verify_response = await syfthub_client.verify_otp(
+                    email=request.email,
+                    code=request.code,
+                )
+                # /verify-otp already issued tokens — skip the extra login round-trip.
+                syfthub_client.authenticate_with_tokens(
+                    verify_response.access_token, verify_response.refresh_token
+                )
+                await self._sync_public_url(syfthub_client)
+            except SyftHubError as e:
+                raise e.to_http_exception() from e
 
-        # Set as default if it matches the default marketplace URL
-        if should_be_default:
+        return await self._persist_marketplace_after_signup(
+            tenant=tenant,
+            url=str(request.url),
+            user=verify_response.user,
+            password=request.password,
+        )
+
+    async def resend_marketplace_otp(
+        self, request: ResendMarketplaceOTPRequest
+    ) -> dict:
+        """Trigger SyftHub to resend a registration OTP."""
+        async with SyftHubClient(str(request.url)) as syfthub_client:
+            try:
+                await syfthub_client.resend_otp(email=request.email)
+            except SyftHubError as e:
+                raise e.to_http_exception() from e
+
+        return {
+            "message": (
+                "If the email is registered and unverified, a new code was sent."
+            )
+        }
+
+    async def _sync_public_url(self, syfthub_client: SyftHubClient) -> None:
+        """Push the locally-configured public URL to SyftHub as the user's domain."""
+        if app_settings.public_url:
+            await syfthub_client.update_profile(domain=str(app_settings.public_url))
+
+    async def _persist_marketplace_after_signup(
+        self,
+        *,
+        tenant: Tenant,
+        url: str,
+        user: UserResponse,
+        password: str,
+    ) -> MarketplaceResponse:
+        """Shared persistence path for register + verify-OTP + connect-new flows."""
+        marketplace = await self.repository.create(
+            Marketplace(
+                tenant_id=tenant.id,
+                name=user.full_name,
+                username=user.username,
+                url=url,
+                email=user.email,
+                password=password,
+                is_default=False,
+                is_active=True,
+            )
+        )
+
+        if str(app_settings.default_marketplace_url) == url:
             marketplace = await self.repository.set_as_default(
                 marketplace.id, tenant.id
             )
@@ -101,56 +170,39 @@ class MarketplaceHandler:
         """
         async with SyftHubClient(str(request.url)) as syfthub_client:
             try:
-                # Login to existing account
                 await syfthub_client.login(request.username, request.password)
-
-                # Fetch user profile
                 user_profile = await syfthub_client.profile()
-
-                # Update domain if public URL is set
-                if app_settings.public_url:
-                    await syfthub_client.update_profile(
-                        domain=str(app_settings.public_url)
-                    )
-
+                await self._sync_public_url(syfthub_client)
             except SyftHubError as e:
                 raise e.to_http_exception() from e
 
-        # Check if the marketplace should be set as default
-        should_be_default = app_settings.default_marketplace_url == request.url
-
-        # Check if the marketplace already exists with the same URL
         existing_marketplace = await self.repository.get_by_url(
             str(request.url), tenant.id
         )
 
-        if existing_marketplace:
-            # Update the marketplace with the new credentials
-            marketplace = await self.repository.update(
-                existing_marketplace.id,
-                tenant.id,
-                name=user_profile.full_name,
-                username=user_profile.username,
-                email=user_profile.email,
-                password=request.password,
-                is_active=True,
-            )
-        else:
-            # Create marketplace entity with the new credentials
-            marketplace = Marketplace(
-                tenant_id=tenant.id,
-                name=user_profile.full_name,
-                username=user_profile.username,
+        if existing_marketplace is None:
+            return await self._persist_marketplace_after_signup(
+                tenant=tenant,
                 url=str(request.url),
-                email=user_profile.email,
+                user=UserResponse(
+                    username=user_profile.username,
+                    email=user_profile.email,
+                    full_name=user_profile.full_name,
+                ),
                 password=request.password,
-                is_default=False,
-                is_active=True,
             )
-            marketplace = await self.repository.create(marketplace)
 
-        # Set as default if it matches the default marketplace URL
-        if should_be_default:
+        marketplace = await self.repository.update(
+            existing_marketplace.id,
+            tenant.id,
+            name=user_profile.full_name,
+            username=user_profile.username,
+            email=user_profile.email,
+            password=request.password,
+            is_active=True,
+        )
+
+        if app_settings.default_marketplace_url == request.url:
             marketplace = await self.repository.set_as_default(
                 marketplace.id, tenant.id
             )

--- a/backend/syft_space/components/marketplaces/routes.py
+++ b/backend/syft_space/components/marketplaces/routes.py
@@ -7,9 +7,12 @@ from fastapi import APIRouter, Depends
 from syft_space.components.marketplaces.handlers import MarketplaceHandler
 from syft_space.components.marketplaces.schemas import (
     ConnectMarketplaceRequest,
+    EmailVerificationRequiredResponse,
     MarketplaceListItem,
     MarketplaceResponse,
     RegisterMarketplaceRequest,
+    ResendMarketplaceOTPRequest,
+    VerifyMarketplaceOTPRequest,
 )
 from syft_space.components.tenants.dependency import get_tenant_dependency
 from syft_space.components.tenants.entities import Tenant
@@ -30,22 +33,61 @@ def build_marketplace_routes(handler: MarketplaceHandler) -> APIRouter:
         """Dependency to get the marketplace handler."""
         return handler
 
-    @router.post("/register", response_model=MarketplaceResponse, status_code=201)
+    @router.post(
+        "/register",
+        response_model=MarketplaceResponse,
+        status_code=201,
+        responses={
+            202: {
+                "model": EmailVerificationRequiredResponse,
+                "description": (
+                    "Account created on SyftHub but email verification is "
+                    "required. Submit the OTP via /marketplaces/verify-otp."
+                ),
+            },
+        },
+    )
     async def register_marketplace(
         request: RegisterMarketplaceRequest,
         tenant: Tenant = Depends(get_tenant_dependency),
         handler: MarketplaceHandler = Depends(get_handler),
-    ) -> MarketplaceResponse:
+    ):
         """Register a new marketplace by creating a new SyftHub account.
 
-        Args:
-            request: Marketplace registration request with credentials
-            tenant: Current tenant (injected)
-
-        Returns:
-            Created marketplace details
+        On success returns 201 with the persisted marketplace. When SyftHub
+        requires OTP verification (SMTP is configured), returns 202 with an
+        ``EmailVerificationRequiredResponse`` so the client can prompt for the
+        emailed code and POST it to /marketplaces/verify-otp.
         """
         return await handler.register_marketplace(request, tenant)
+
+    @router.post(
+        "/verify-otp",
+        response_model=MarketplaceResponse,
+        status_code=201,
+        responses={
+            400: {"description": "Invalid or expired OTP code"},
+            404: {"description": "No pending verification for this email"},
+        },
+    )
+    async def verify_marketplace_otp(
+        request: VerifyMarketplaceOTPRequest,
+        tenant: Tenant = Depends(get_tenant_dependency),
+        handler: MarketplaceHandler = Depends(get_handler),
+    ) -> MarketplaceResponse:
+        """Complete a pending marketplace registration with an emailed OTP code.
+
+        Used after ``/register`` returns 202 with ``EMAIL_VERIFICATION_REQUIRED``.
+        """
+        return await handler.verify_marketplace_otp(request, tenant)
+
+    @router.post("/resend-otp", status_code=200)
+    async def resend_marketplace_otp(
+        request: ResendMarketplaceOTPRequest,
+        handler: MarketplaceHandler = Depends(get_handler),
+    ) -> dict:
+        """Resend a registration OTP code to the given email."""
+        return await handler.resend_marketplace_otp(request)
 
     @router.post("/connect", response_model=MarketplaceResponse, status_code=201)
     async def connect_marketplace(

--- a/backend/syft_space/components/marketplaces/schemas.py
+++ b/backend/syft_space/components/marketplaces/schemas.py
@@ -7,6 +7,8 @@ from pydantic import BaseModel, EmailStr, Field, HttpUrl
 
 from syft_space.config import app_settings
 
+EMAIL_VERIFICATION_REQUIRED_CODE = "EMAIL_VERIFICATION_REQUIRED"
+
 
 class RegisterMarketplaceRequest(BaseModel):
     """Request model for registering a new marketplace (new SyftHub account)."""
@@ -54,6 +56,43 @@ class ConnectMarketplaceRequest(BaseModel):
                 "url": "https://marketplace.example.com",
             }
         }
+
+
+class VerifyMarketplaceOTPRequest(BaseModel):
+    """Request to complete a pending marketplace registration via OTP."""
+
+    url: HttpUrl = Field(
+        description="Marketplace base URL",
+        default=app_settings.default_marketplace_url,
+    )
+    email: EmailStr = Field(..., description="Email that received the OTP")
+    password: str = Field(..., description="Password chosen during registration")
+    code: str = Field(
+        ...,
+        min_length=6,
+        max_length=6,
+        pattern=r"^\d{6}$",
+        description="6-digit OTP code",
+    )
+
+
+class EmailVerificationRequiredResponse(BaseModel):
+    """202 response returned by /register when SyftHub requires OTP verification."""
+
+    code: str = Field(default=EMAIL_VERIFICATION_REQUIRED_CODE)
+    message: str
+    email: EmailStr
+    url: str
+
+
+class ResendMarketplaceOTPRequest(BaseModel):
+    """Request to resend a marketplace registration OTP."""
+
+    url: HttpUrl = Field(
+        description="Marketplace base URL",
+        default=app_settings.default_marketplace_url,
+    )
+    email: EmailStr = Field(..., description="Email to receive a fresh OTP")
 
 
 class MarketplaceResponse(BaseModel):

--- a/backend/syft_space/components/shared/syfthub_client.py
+++ b/backend/syft_space/components/shared/syfthub_client.py
@@ -42,8 +42,22 @@ class SyftHubError(Exception):
         super().__init__(message)
 
     def to_http_exception(self) -> HTTPException:
-        """Convert to FastAPI HTTPException."""
-        return HTTPException(status_code=self.status_code, detail=self.message)
+        """Convert to FastAPI HTTPException.
+
+        When the upstream error carries a structured ``code`` (e.g.
+        ``EMAIL_NOT_VERIFIED``), surface it as a dict so the frontend can
+        branch on it. Otherwise fall back to the historical string detail so
+        existing error toasts keep rendering unchanged.
+        """
+        if self.code is None and self.field is None:
+            return HTTPException(status_code=self.status_code, detail=self.message)
+
+        detail: dict[str, Any] = {"message": self.message}
+        if self.code is not None:
+            detail["code"] = self.code
+        if self.field is not None:
+            detail["field"] = self.field
+        return HTTPException(status_code=self.status_code, detail=detail)
 
 
 class AuthenticationError(SyftHubError):
@@ -125,7 +139,23 @@ class UserResponse(BaseModel):
 
 
 class RegisterResponse(BaseModel):
-    """Response from registration endpoint."""
+    """Response from registration endpoint.
+
+    When SyftHub has SMTP configured, registration becomes a two-step flow:
+    tokens come back null and ``requires_email_verification`` is True. The
+    client must then call ``/auth/register/verify-otp`` with the code emailed
+    to the user before tokens are issued.
+    """
+
+    user: UserResponse
+    access_token: str | None = None
+    refresh_token: str | None = None
+    token_type: str = "bearer"
+    requires_email_verification: bool = False
+
+
+class VerifyOTPResponse(BaseModel):
+    """Response from /auth/register/verify-otp on SyftHub."""
 
     user: UserResponse
     access_token: str
@@ -409,6 +439,32 @@ class SyftHubClient:
         response = await self._auth_client.post("/api/v1/auth/register", json=payload)
         return _handle_response(response, RegisterResponse)
 
+    async def verify_otp(self, email: str, code: str) -> VerifyOTPResponse:
+        """Verify a registration OTP and obtain tokens.
+
+        Raises:
+            ValidationError: Invalid/expired code or malformed input
+            NotFoundError: No pending verification for this email
+            ServerError: Server-side error
+        """
+        response = await self._auth_client.post(
+            "/api/v1/auth/register/verify-otp",
+            json={"email": email, "code": code},
+        )
+        return _handle_response(response, VerifyOTPResponse)
+
+    async def resend_otp(self, email: str) -> None:
+        """Request a fresh registration OTP for an unverified email.
+
+        SyftHub intentionally returns a generic success message regardless of
+        whether the email exists, so this method does not surface a model.
+        """
+        response = await self._auth_client.post(
+            "/api/v1/auth/register/resend-otp",
+            json={"email": email},
+        )
+        _handle_response_raw(response)
+
     async def _is_username_available(self, username: str) -> bool:
         """
         Check if a username is available.
@@ -419,6 +475,24 @@ class SyftHubClient:
             f"/api/v1/users/check-username/{username}"
         )
         return _handle_response_raw(response)["available"]
+
+    def authenticate_with_tokens(self, access_token: str, refresh_token: str) -> None:
+        """Seed the authenticated client from pre-fetched tokens.
+
+        Used when a sibling endpoint (e.g. /auth/register/verify-otp) already
+        issued tokens — skips the extra /auth/login round-trip.
+        """
+        self._tokens = TokenResponse(
+            access_token=access_token, refresh_token=refresh_token
+        )
+        auth = AsyncRefreshTokenAuth(
+            auth_client=self._auth_client,
+            access_token=access_token,
+            refresh_token=refresh_token,
+        )
+        self._client = httpx.AsyncClient(
+            base_url=self.base_url, auth=auth, timeout=self._timeout
+        )
 
     async def login(self, username: str, password: str) -> TokenResponse:
         """
@@ -434,17 +508,7 @@ class SyftHubClient:
             data={"username": username, "password": password},
         )
         tokens = _handle_response(response, TokenResponse)
-        self._tokens = tokens
-
-        # Setup authenticated client with auto-refresh
-        auth = AsyncRefreshTokenAuth(
-            auth_client=self._auth_client,
-            access_token=tokens.access_token,
-            refresh_token=tokens.refresh_token,
-        )
-        self._client = httpx.AsyncClient(
-            base_url=self.base_url, auth=auth, timeout=self._timeout
-        )
+        self.authenticate_with_tokens(tokens.access_token, tokens.refresh_token)
         return tokens
 
     async def accounting_credentials(self) -> AccountingResponse:

--- a/frontend/src/api/endpoints/marketplaces.ts
+++ b/frontend/src/api/endpoints/marketplaces.ts
@@ -1,21 +1,47 @@
 import { apiClient } from '../client'
-import type {
-  RegisterMarketplaceRequest,
-  ConnectMarketplaceRequest,
-  MarketplaceResponse,
-  MarketplaceListItem,
+import {
+  MarketplaceErrorCode,
+  type RegisterMarketplaceRequest,
+  type ConnectMarketplaceRequest,
+  type MarketplaceResponse,
+  type MarketplaceListItem,
+  type VerifyMarketplaceOTPRequest,
+  type ResendMarketplaceOTPRequest,
 } from '../types'
 
+export type RegisterMarketplaceResult =
+  | { kind: 'success'; marketplace: MarketplaceResponse }
+  | { kind: 'verification_required'; email: string; url: string; message: string }
+
 export const marketplacesApi = {
-  // Register a new marketplace (create new SyftHub account)
-  register: async (data: RegisterMarketplaceRequest): Promise<MarketplaceResponse> => {
+  register: async (data: RegisterMarketplaceRequest): Promise<RegisterMarketplaceResult> => {
     const response = await apiClient.post('/marketplaces/register', data)
+    if (
+      response.status === 202 &&
+      response.data?.code === MarketplaceErrorCode.EmailVerificationRequired
+    ) {
+      return {
+        kind: 'verification_required',
+        email: response.data.email,
+        url: response.data.url,
+        message: response.data.message,
+      }
+    }
+    return { kind: 'success', marketplace: response.data as MarketplaceResponse }
+  },
+
+  connect: async (data: ConnectMarketplaceRequest): Promise<MarketplaceResponse> => {
+    const response = await apiClient.post('/marketplaces/connect', data)
     return response.data
   },
 
-  // Connect to existing SyftHub account
-  connect: async (data: ConnectMarketplaceRequest): Promise<MarketplaceResponse> => {
-    const response = await apiClient.post('/marketplaces/connect', data)
+  verifyOtp: async (data: VerifyMarketplaceOTPRequest): Promise<MarketplaceResponse> => {
+    const response = await apiClient.post('/marketplaces/verify-otp', data)
+    return response.data
+  },
+
+  resendOtp: async (data: ResendMarketplaceOTPRequest): Promise<{ message: string }> => {
+    const response = await apiClient.post('/marketplaces/resend-otp', data)
     return response.data
   },
 

--- a/frontend/src/api/types/index.ts
+++ b/frontend/src/api/types/index.ts
@@ -327,6 +327,23 @@ export interface ConnectMarketplaceRequest {
   url?: string
 }
 
+export interface VerifyMarketplaceOTPRequest {
+  url?: string
+  email: string
+  password: string
+  code: string
+}
+
+export interface ResendMarketplaceOTPRequest {
+  url?: string
+  email: string
+}
+
+export const MarketplaceErrorCode = {
+  EmailVerificationRequired: 'EMAIL_VERIFICATION_REQUIRED',
+  EmailNotVerified: 'EMAIL_NOT_VERIFIED',
+} as const
+
 export interface MarketplaceResponse {
   id: string
   name: string

--- a/frontend/src/components/EmailOtpDialog.vue
+++ b/frontend/src/components/EmailOtpDialog.vue
@@ -1,0 +1,157 @@
+<template>
+  <Dialog v-model:open="isOpen">
+    <DialogContent class="sm:max-w-[440px]">
+      <DialogHeader>
+        <DialogTitle>Verify your email</DialogTitle>
+        <DialogDescription>
+          Enter the 6-digit code we sent to
+          <span class="font-medium text-foreground">{{ email }}</span
+          >.
+        </DialogDescription>
+      </DialogHeader>
+
+      <form @submit.prevent="handleSubmit" class="space-y-4">
+        <div class="space-y-2">
+          <Label for="otp-code">Verification code</Label>
+          <Input
+            id="otp-code"
+            v-model="code"
+            inputmode="numeric"
+            autocomplete="one-time-code"
+            maxlength="6"
+            placeholder="123456"
+            :class="{ 'border-red-500': !!error }"
+            @input="onCodeInput"
+          />
+          <p class="body-sm text-muted-foreground">
+            The code expires after 10 minutes. Didn't get one?
+            <button
+              type="button"
+              class="text-primary hover:underline disabled:opacity-50 disabled:cursor-not-allowed"
+              :disabled="resending || verifying"
+              @click="handleResend"
+            >
+              {{ resending ? 'Sending…' : 'Resend code' }}
+            </button>
+          </p>
+          <p v-if="resendNotice" class="body-sm text-green-600">{{ resendNotice }}</p>
+        </div>
+
+        <Alert v-if="error" variant="destructive">
+          <AlertDescription>{{ error }}</AlertDescription>
+        </Alert>
+
+        <DialogFooter class="gap-2">
+          <Button type="button" variant="outline" :disabled="verifying" @click="handleCancel">
+            Cancel
+          </Button>
+          <Button type="submit" :disabled="!isValid || verifying">
+            <Loader2 v-if="verifying" class="mr-2 h-4 w-4 animate-spin" />
+            Verify
+          </Button>
+        </DialogFooter>
+      </form>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import { Loader2 } from 'lucide-vue-next'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog'
+
+interface Props {
+  open: boolean
+  email: string
+  verifying?: boolean
+  resending?: boolean
+  error?: string
+  // Set when SyftHub didn't emit a code on its own (e.g. an existing
+  // unverified account hitting login); the dialog will request one on open.
+  autoResend?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  verifying: false,
+  resending: false,
+  error: '',
+  autoResend: false,
+})
+
+const emit = defineEmits<{
+  'update:open': [value: boolean]
+  verify: [code: string]
+  resend: []
+  cancel: []
+}>()
+
+const code = ref('')
+const resendNotice = ref('')
+
+const isOpen = computed({
+  get: () => props.open,
+  set: (value) => emit('update:open', value),
+})
+
+const isValid = computed(() => /^\d{6}$/.test(code.value))
+
+const onCodeInput = () => {
+  code.value = code.value.replace(/\D+/g, '').slice(0, 6)
+}
+
+const handleSubmit = () => {
+  if (!isValid.value || props.verifying) return
+  emit('verify', code.value)
+}
+
+const handleResend = () => {
+  resendNotice.value = ''
+  emit('resend')
+}
+
+const handleCancel = () => {
+  emit('cancel')
+  emit('update:open', false)
+}
+
+let resendAttempted = false
+
+watch(
+  () => props.open,
+  async (value) => {
+    if (!value) return
+    code.value = ''
+    resendNotice.value = ''
+    resendAttempted = false
+    await nextTick()
+    document.getElementById('otp-code')?.focus()
+    if (props.autoResend) emit('resend')
+  },
+)
+
+// Resend success has no direct signal — infer it from `resending` flipping
+// back to false without an error after the user (or auto-resend) triggered one.
+watch(
+  () => props.resending,
+  (now, prev) => {
+    if (now) {
+      resendAttempted = true
+      return
+    }
+    if (prev && resendAttempted && !props.error) {
+      resendNotice.value = 'A fresh code has been sent.'
+    }
+  },
+)
+</script>

--- a/frontend/src/composables/useOnboarding.ts
+++ b/frontend/src/composables/useOnboarding.ts
@@ -1,6 +1,34 @@
 import { ref, type Ref } from 'vue'
+import axios from 'axios'
 import { marketplacesApi } from '@/api/endpoints/marketplaces'
 import { settingsApi } from '@/api/endpoints/settings'
+import { MarketplaceErrorCode } from '@/api/types'
+
+interface ErrorDetail {
+  code?: string
+  message?: string
+  field?: string
+}
+
+function extractDetail(error: unknown): ErrorDetail | null {
+  if (!axios.isAxiosError(error)) return null
+  const detail = error.response?.data?.detail
+  if (typeof detail === 'string') return { message: detail }
+  if (detail && typeof detail === 'object') return detail as ErrorDetail
+  return null
+}
+
+function extractDetailMessage(error: unknown, fallback: string): string {
+  return extractDetail(error)?.message || fallback
+}
+
+interface PendingVerification {
+  email: string
+  password: string
+  url?: string
+  // 'signin' triggers an auto-resend when the dialog opens; 'register' doesn't.
+  origin: 'register' | 'signin'
+}
 
 // Helper function to check if user is already onboarded
 export async function checkOnboardingStatus(): Promise<boolean> {
@@ -53,6 +81,12 @@ export function useOnboarding() {
   // Stored marketplace data after successful auth
   const marketplaceData: Ref<{ id: string; username: string } | null> = ref(null)
 
+  // OTP / email verification state
+  const pendingVerification: Ref<PendingVerification | null> = ref(null)
+  const verifyingOtp = ref(false)
+  const resendingOtp = ref(false)
+  const otpError = ref('')
+
   // Check username availability with debouncing
   const checkUsernameAvailability = async (username: string) => {
     // Clear previous timeout
@@ -83,46 +117,43 @@ export function useOnboarding() {
     }, 500) as unknown as number
   }
 
-  // Register new account
   const register = async (): Promise<boolean> => {
     registering.value = true
     authError.value = ''
 
     try {
-      const response = await marketplacesApi.register({
+      const result = await marketplacesApi.register({
         name: registerForm.value.name,
         username: registerForm.value.username,
         email: registerForm.value.email,
         password: registerForm.value.password,
-        // url will use backend default
       })
 
-      // Store marketplace data for later use
+      if (result.kind === 'verification_required') {
+        pendingVerification.value = {
+          email: result.email,
+          password: registerForm.value.password,
+          url: result.url,
+          origin: 'register',
+        }
+        return false
+      }
+
       marketplaceData.value = {
-        id: response.id,
+        id: result.marketplace.id,
         username: registerForm.value.username,
       }
 
       return true
     } catch (error) {
       console.error('Registration failed:', error)
-      if (error && typeof error === 'object' && 'response' in error) {
-        const axiosError = error as { response?: { data?: { detail?: string } } }
-        if (axiosError.response?.data?.detail) {
-          authError.value = axiosError.response.data.detail
-        } else {
-          authError.value = 'Failed to create account. Please try again.'
-        }
-      } else {
-        authError.value = 'Failed to create account. Please try again.'
-      }
+      authError.value = extractDetailMessage(error, 'Failed to create account. Please try again.')
       return false
     } finally {
       registering.value = false
     }
   }
 
-  // Sign in to existing account
   const signIn = async (): Promise<boolean> => {
     signingIn.value = true
     authError.value = ''
@@ -131,10 +162,8 @@ export function useOnboarding() {
       const response = await marketplacesApi.connect({
         username: signinForm.value.username,
         password: signinForm.value.password,
-        // url will use backend default
       })
 
-      // Store marketplace data for later use
       marketplaceData.value = {
         id: response.id,
         username: signinForm.value.username,
@@ -143,20 +172,93 @@ export function useOnboarding() {
       return true
     } catch (error) {
       console.error('Sign in failed:', error)
-      if (error && typeof error === 'object' && 'response' in error) {
-        const axiosError = error as { response?: { data?: { detail?: string } } }
-        if (axiosError.response?.data?.detail) {
-          authError.value = axiosError.response.data.detail
-        } else {
-          authError.value = 'Invalid username or password. Please try again.'
+      const detail = extractDetail(error)
+      // Only route into the OTP dialog when we have an email to address the
+      // resend to — SyftHub's login form also accepts username, in which case
+      // we can't drive the verification flow and fall back to the error toast.
+      if (
+        detail?.code === MarketplaceErrorCode.EmailNotVerified &&
+        signinForm.value.username.includes('@')
+      ) {
+        pendingVerification.value = {
+          email: signinForm.value.username,
+          password: signinForm.value.password,
+          origin: 'signin',
         }
-      } else {
-        authError.value = 'Invalid username or password. Please try again.'
+        return false
       }
+      authError.value = detail?.message || 'Invalid username or password. Please try again.'
       return false
     } finally {
       signingIn.value = false
     }
+  }
+
+  const verifyOtp = async (code: string): Promise<boolean> => {
+    if (!pendingVerification.value) {
+      otpError.value = 'No verification is in progress.'
+      return false
+    }
+
+    verifyingOtp.value = true
+    otpError.value = ''
+
+    try {
+      const response = await marketplacesApi.verifyOtp({
+        email: pendingVerification.value.email,
+        password: pendingVerification.value.password,
+        url: pendingVerification.value.url,
+        code,
+      })
+
+      marketplaceData.value = {
+        id: response.id,
+        username: response.name,
+      }
+      pendingVerification.value = null
+      return true
+    } catch (error) {
+      console.error('OTP verification failed:', error)
+      otpError.value = extractDetailMessage(
+        error,
+        'Could not verify that code. Try again or request a new one.',
+      )
+      return false
+    } finally {
+      verifyingOtp.value = false
+    }
+  }
+
+  const resendOtp = async (): Promise<boolean> => {
+    if (!pendingVerification.value) {
+      otpError.value = 'No verification is in progress.'
+      return false
+    }
+
+    resendingOtp.value = true
+    otpError.value = ''
+
+    try {
+      await marketplacesApi.resendOtp({
+        email: pendingVerification.value.email,
+        url: pendingVerification.value.url,
+      })
+      return true
+    } catch (error) {
+      console.error('OTP resend failed:', error)
+      otpError.value = extractDetailMessage(
+        error,
+        'Could not resend the code. Please try again in a minute.',
+      )
+      return false
+    } finally {
+      resendingOtp.value = false
+    }
+  }
+
+  const cancelVerification = () => {
+    pendingVerification.value = null
+    otpError.value = ''
   }
 
   // Complete setup (save network configuration)
@@ -237,6 +339,8 @@ export function useOnboarding() {
     authError.value = ''
     networkError.value = ''
     marketplaceData.value = null
+    pendingVerification.value = null
+    otpError.value = ''
   }
 
   return {
@@ -269,10 +373,19 @@ export function useOnboarding() {
     // Marketplace data (set after auth success)
     marketplaceData,
 
+    // OTP / email verification state
+    pendingVerification,
+    verifyingOtp,
+    resendingOtp,
+    otpError,
+
     // Methods
     checkUsernameAvailability,
     register,
     signIn,
+    verifyOtp,
+    resendOtp,
+    cancelVerification,
     completeSetup,
     loadExistingState,
     reset,

--- a/frontend/src/pages/OnboardingPage.vue
+++ b/frontend/src/pages/OnboardingPage.vue
@@ -293,6 +293,18 @@
         </CardContent>
       </Card>
     </div>
+
+    <EmailOtpDialog
+      v-model:open="otpDialogOpen"
+      :email="pendingVerification?.email ?? ''"
+      :verifying="verifyingOtp"
+      :resending="resendingOtp"
+      :error="otpError"
+      :auto-resend="pendingVerification?.origin === 'signin'"
+      @verify="handleVerifyOtp"
+      @resend="resendOtp"
+      @cancel="cancelVerification"
+    />
   </div>
 </template>
 
@@ -314,6 +326,7 @@ import { setPosthogDiagnosticsEnabled } from '@/lib/posthog'
 import { useOnboarding } from '@/composables/useOnboarding'
 import { loadGlobalData } from '@/lib/utils'
 import { checkOnboardingStatus, clearOnboardingCache } from '@/router'
+import EmailOtpDialog from '@/components/EmailOtpDialog.vue'
 
 const router = useRouter()
 const route = useRoute()
@@ -355,12 +368,56 @@ const {
   authError,
   networkError,
   marketplaceData,
+  pendingVerification,
+  verifyingOtp,
+  resendingOtp,
+  otpError,
   checkUsernameAvailability,
   register,
   signIn,
+  verifyOtp,
+  resendOtp,
+  cancelVerification,
   completeSetup,
   loadExistingState,
 } = useOnboarding()
+
+const otpDialogOpen = computed({
+  get: () => pendingVerification.value !== null,
+  set: (value) => {
+    if (!value) cancelVerification()
+  },
+})
+
+const handleVerifyOtp = async (code: string) => {
+  const ok = await verifyOtp(code)
+  if (!ok) return
+  await finalizeSetup()
+}
+
+const finalizeSetup = async () => {
+  isSubmitting.value = true
+  try {
+    const setupSuccess = await completeSetup()
+    if (!setupSuccess) return
+
+    await settingsApi.updateDiagnostics({ enabled: diagnosticsOptIn.value })
+    setDiagnosticsEnabled(diagnosticsOptIn.value)
+    setPosthogDiagnosticsEnabled(diagnosticsOptIn.value)
+
+    clearOnboardingCache()
+    await loadGlobalData()
+
+    const nextUrl = route.query.next as string | undefined
+    if (nextUrl) {
+      router.push(nextUrl)
+    } else {
+      router.push({ name: 'home' })
+    }
+  } finally {
+    isSubmitting.value = false
+  }
+}
 
 // Additional form state
 const confirmPassword = ref('')
@@ -422,41 +479,13 @@ const handleCompleteSetup = async () => {
   try {
     // Skip auth if already registered (retry after network failure)
     if (!isAlreadyRegistered.value) {
-      let authSuccess = false
-      if (authMode.value === 'register') {
-        authSuccess = await register()
-      } else {
-        authSuccess = await signIn()
-      }
-
-      if (!authSuccess) {
-        isSubmitting.value = false
-        return
-      }
+      const authSuccess = authMode.value === 'register' ? await register() : await signIn()
+      // authSuccess can be false either because auth failed outright or
+      // because the OTP dialog is now driving completion — either way, stop.
+      if (!authSuccess) return
     }
 
-    // Complete the setup
-    const setupSuccess = await completeSetup()
-    if (setupSuccess) {
-      // Save diagnostics preference and update Sentry
-      await settingsApi.updateDiagnostics({ enabled: diagnosticsOptIn.value })
-      setDiagnosticsEnabled(diagnosticsOptIn.value)
-      setPosthogDiagnosticsEnabled(diagnosticsOptIn.value)
-
-      // Clear cache so next check gets fresh status
-      clearOnboardingCache()
-
-      // Fetch global data now that onboarding is complete
-      await loadGlobalData()
-
-      // Redirect to the original destination or home
-      const nextUrl = route.query.next as string | undefined
-      if (nextUrl) {
-        router.push(nextUrl)
-      } else {
-        router.push({ name: 'home' })
-      }
-    }
+    await finalizeSetup()
   } finally {
     isSubmitting.value = false
   }


### PR DESCRIPTION
## Summary

SyftHub now returns `201` with `access_token: null` / `refresh_token: null` and `requires_email_verification: true` when SMTP is configured. Syft Space's `RegisterResponse` modelled tokens as required strings, so `/api/v1/marketplaces/register` crashed with a Pydantic `ValidationError` (500) on every new registration — the user's SyftHub account was created but Syft Space never persisted a marketplace row. The "I have an account" fallback then 403'd with `EMAIL_NOT_VERIFIED` and no UI to enter the code.

This change adds full OTP support end-to-end:

- **Schema sync.** `RegisterResponse` mirrors SyftHub's contract — tokens are optional, with a `requires_email_verification` discriminator.
- **Client.** New `SyftHubClient.verify_otp(email, code)` / `resend_otp(email)` wrap SyftHub's `/auth/register/{verify,resend}-otp`. New `authenticate_with_tokens(...)` lets us seed the auth flow from `/verify-otp`'s tokens, skipping an extra `/login` round-trip.
- **Backend routes.** `POST /api/v1/marketplaces/register` now returns `202` with code `EMAIL_VERIFICATION_REQUIRED` when SyftHub asks for OTP, instead of attempting the doomed login. New `POST /api/v1/marketplaces/verify-otp` and `/resend-otp` drive the second leg for both fresh registration and connecting an existing unverified account.
- **Structured errors.** `SyftHubError.to_http_exception()` now preserves the upstream `code` (e.g. `EMAIL_NOT_VERIFIED`) when present, with a backward-compatible string-detail fallback when no code is available.
- **Frontend.** New `EmailOtpDialog.vue` (shadcn `Dialog` + numeric input + resend). `useOnboarding` exposes a pending-verification state machine that opens the dialog from either the register or signin path and re-enters network setup on success. Backend route reused via a typed `RegisterMarketplaceResult` discriminated union.
- **Drive-by:** factored `_persist_marketplace_after_signup` and `_sync_public_url` and pointed `connect_marketplace`'s new-marketplace branch at them — eliminates ~40 lines of duplication. Added a `^\d{6}$` pattern on the OTP request body.

## Test plan

- [ ] **Register, SMTP off.** SyftHub returns tokens → marketplace row created → onboarding completes. (Regression check; should be unchanged.)
- [ ] **Register, SMTP on.** Backend returns `202` with `EMAIL_VERIFICATION_REQUIRED`. Frontend opens `EmailOtpDialog`. Entering the emailed code calls `/marketplaces/verify-otp` → marketplace row created → network setup completes.
- [ ] **Resend during register flow.** Click "Resend code" → `/marketplaces/resend-otp` called → "A fresh code has been sent." notice shown.
- [ ] **Connect existing unverified account.** Sign in with the email → backend surfaces `403 EMAIL_NOT_VERIFIED` as `{detail: {code, message}}` → frontend auto-opens the dialog and auto-triggers a resend (since SyftHub doesn't emit a code on failed login).
- [ ] **Invalid / expired code.** SyftHub returns `400` → dialog shows the structured error message without closing.
- [ ] **Cancel during OTP.** Closing the dialog returns to the form without persisting anything.
- [ ] **OpenAPI.** `/docs` shows `register` advertising both `201 MarketplaceResponse` and `202 EmailVerificationRequiredResponse`.
