### PR TITLE
refactor(marketplaces): move 202 transport out of register handler

### DIFF
--- a/backend/syft_space/components/marketplaces/handlers.py
+++ b/backend/syft_space/components/marketplaces/handlers.py
@@ -3,13 +3,12 @@
 from uuid import UUID
 
 from fastapi import HTTPException
-from fastapi.responses import JSONResponse
 
 from syft_space.components.marketplaces.entities import Marketplace
 from syft_space.components.marketplaces.repository import MarketplaceRepository
 from syft_space.components.marketplaces.schemas import (
-    EMAIL_VERIFICATION_REQUIRED_CODE,
     ConnectMarketplaceRequest,
+    EmailVerificationRequiredResponse,
     MarketplaceListItem,
     MarketplaceResponse,
     RegisterMarketplaceRequest,
@@ -38,13 +37,13 @@ class MarketplaceHandler:
 
     async def register_marketplace(
         self, request: RegisterMarketplaceRequest, tenant: Tenant
-    ) -> MarketplaceResponse | JSONResponse:
+    ) -> MarketplaceResponse | EmailVerificationRequiredResponse:
         """Register a new marketplace by creating a new SyftHub account.
 
-        Returns a 201 MarketplaceResponse on success. When SyftHub requires
-        email verification, returns a 202 JSON body with code
-        ``EMAIL_VERIFICATION_REQUIRED`` so the client can collect the OTP
-        and call ``/verify-otp`` to finish setup.
+        Returns a ``MarketplaceResponse`` on success. When SyftHub requires
+        email verification, returns an ``EmailVerificationRequiredResponse``
+        so the route layer can surface a 202 and the client can collect the
+        OTP and call ``/verify-otp`` to finish setup.
         """
         async with SyftHubClient(str(request.url)) as syfthub_client:
             try:
@@ -56,17 +55,13 @@ class MarketplaceHandler:
                 )
 
                 if register_response.requires_email_verification:
-                    return JSONResponse(
-                        status_code=202,
-                        content={
-                            "code": EMAIL_VERIFICATION_REQUIRED_CODE,
-                            "message": (
-                                "Account created. Enter the verification code "
-                                "sent to your email to finish setup."
-                            ),
-                            "email": request.email,
-                            "url": str(request.url),
-                        },
+                    return EmailVerificationRequiredResponse(
+                        message=(
+                            "Account created. Enter the verification code "
+                            "sent to your email to finish setup."
+                        ),
+                        email=request.email,
+                        url=str(request.url),
                     )
 
                 await syfthub_client.login(request.email, request.password)

--- a/backend/syft_space/components/marketplaces/routes.py
+++ b/backend/syft_space/components/marketplaces/routes.py
@@ -2,7 +2,8 @@
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Response
+from fastapi.responses import JSONResponse
 
 from syft_space.components.marketplaces.handlers import MarketplaceHandler
 from syft_space.components.marketplaces.schemas import (
@@ -51,7 +52,7 @@ def build_marketplace_routes(handler: MarketplaceHandler) -> APIRouter:
         request: RegisterMarketplaceRequest,
         tenant: Tenant = Depends(get_tenant_dependency),
         handler: MarketplaceHandler = Depends(get_handler),
-    ):
+    ) -> Response:
         """Register a new marketplace by creating a new SyftHub account.
 
         On success returns 201 with the persisted marketplace. When SyftHub
@@ -59,7 +60,10 @@ def build_marketplace_routes(handler: MarketplaceHandler) -> APIRouter:
         ``EmailVerificationRequiredResponse`` so the client can prompt for the
         emailed code and POST it to /marketplaces/verify-otp.
         """
-        return await handler.register_marketplace(request, tenant)
+        result = await handler.register_marketplace(request, tenant)
+        if isinstance(result, EmailVerificationRequiredResponse):
+            return JSONResponse(status_code=202, content=result.model_dump(mode="json"))
+        return JSONResponse(status_code=201, content=result.model_dump(mode="json"))
 
     @router.post(
         "/verify-otp",


### PR DESCRIPTION
This pull request refactors how the API handles responses when registering a new marketplace, specifically improving the handling of cases where email verification is required. The main goal is to return more structured and type-safe responses, making it easier for the client to interpret and handle different registration outcomes.

**Improvements to response handling:**

* Changed the handler method `register_marketplace` to return an `EmailVerificationRequiredResponse` object instead of a generic `JSONResponse` when email verification is needed, improving type safety and clarity. [[1]](diffhunk://#diff-7f8217e030e87974a05bf0d841fc588568c16de2f768a072ee74e21c34e7f4d1L41-R46) [[2]](diffhunk://#diff-7f8217e030e87974a05bf0d841fc588568c16de2f768a072ee74e21c34e7f4d1L59-R64)
* Updated the route to check for `EmailVerificationRequiredResponse` and explicitly return a 202 status with the correct response model, while always returning a 201 with the marketplace response on success.

**Code cleanup and imports:**

* Removed unused imports of `JSONResponse` and the `EMAIL_VERIFICATION_REQUIRED_CODE` constant from `handlers.py`, and adjusted imports in `routes.py` to support the new response logic. [[1]](diffhunk://#diff-7f8217e030e87974a05bf0d841fc588568c16de2f768a072ee74e21c34e7f4d1L6-R11) [[2]](diffhunk://#diff-293fc0c7e30eea54f892322b8e42edbcff3a8ab4dca2c768dd0d3b97d9486f38L5-R6)