### PR TITLE
Encourage Conventional Commits throughtout

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -1,0 +1,67 @@
+name: commit-lint
+
+# Advisory check: walks the commits introduced by a PR and verifies each
+# subject line follows Conventional Commits.
+#
+# Intentionally NOT a required check — do not add this to branch protection
+# yet. It surfaces non-conforming commits in the PR's checks tab and step
+# summary so we can shake out commit-discipline gaps before flipping it on.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate commit subjects
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -uo pipefail
+
+          pattern='^(feat|fix|chore|refactor|perf|docs|test|ci|build|style|revert)(\([a-z0-9._/-]+\))?!?: .+'
+
+          total=0
+          bad=0
+          rows=""
+          while IFS=$'\t' read -r sha subject; do
+            total=$((total+1))
+            safe_subject=${subject//|/\\|}
+            if printf '%s' "$subject" | grep -Eq "$pattern"; then
+              rows+="| \`${sha:0:7}\` | pass | ${safe_subject} |"$'\n'
+            else
+              rows+="| \`${sha:0:7}\` | fail | ${safe_subject} |"$'\n'
+              bad=$((bad+1))
+            fi
+          done < <(git log --reverse --format='%H%x09%s' "$BASE_SHA..$HEAD_SHA")
+
+          {
+            echo "## Conventional Commits check"
+            echo ""
+            if [ "$total" -eq 0 ]; then
+              echo "_No commits to check._"
+            else
+              echo "**$((total - bad)) / $total** commit(s) follow Conventional Commits."
+              echo ""
+              echo "| Commit | Status | Subject |"
+              echo "| --- | --- | --- |"
+              printf '%s' "$rows"
+            fi
+            echo ""
+            echo "_Advisory check — does not block merge. See <https://www.conventionalcommits.org/>._"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$bad" -gt 0 ]; then
+            echo "::warning::${bad} commit(s) do not follow Conventional Commits — see job summary."
+            exit 1
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,9 @@ repos:
           - style
           - revert
 
+# Install both git-hook stages on `pre-commit install` (no `--hook-type` needed).
+default_install_hook_types: [pre-commit, commit-msg]
+
 # Configuration for pre-commit
 default_language_version:
   python: python3.12

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,9 +49,30 @@ repos:
         additional_dependencies: ["bandit[toml]"]
         files: ^backend/
 
+  # Conventional Commits — validates commit subject lines.
+  # Requires opt-in: `pre-commit install --hook-type commit-msg`
+  # (the default `pre-commit install` only wires the pre-commit stage).
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.6.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args:
+          - feat
+          - fix
+          - chore
+          - refactor
+          - perf
+          - docs
+          - test
+          - ci
+          - build
+          - style
+          - revert
+
 # Configuration for pre-commit
 default_language_version:
-  python: python3.9
+  python: python3.12
 
 # Run pre-commit on all files or just staged files
 ci:


### PR DESCRIPTION
This pull request introduces a new advisory commit lint workflow and enhances local commit message validation to encourage the use of Conventional Commits throughout the development process. These changes help surface non-conforming commits early, both in CI and during local development, making it easier for the team to adopt and enforce consistent commit message standards.

**Commit message validation improvements:**

* Added a new GitHub Actions workflow (`.github/workflows/commit-lint.yml`) that checks all PR commits for compliance with the Conventional Commits specification and surfaces results in the PR checks tab. This check is advisory and does not block merges yet.
* Integrated the `conventional-pre-commit` hook into `.pre-commit-config.yaml` to validate commit messages locally when using pre-commit, supporting all major Conventional Commit types. Also configured pre-commit to install both `pre-commit` and `commit-msg` hooks by default for easier setup.

**Tooling updates:**

* Updated the default Python version for pre-commit hooks from `python3.9` to `python3.12` in `.pre-commit-config.yaml`.