### PR TITLE
refactor(ingestion): source-agnostic IngestionJob schema

### DIFF
--- a/backend/syft_space/alembic/versions/d9b3cb044bc7_add_external_id_and_fingerprint_to_.py
+++ b/backend/syft_space/alembic/versions/d9b3cb044bc7_add_external_id_and_fingerprint_to_.py
@@ -1,0 +1,77 @@
+"""add external_id and fingerprint to ingestion_jobs
+
+Revision ID: d9b3cb044bc7
+Revises: b2f4a3c7e108
+Create Date: 2026-06-03 12:06:05.429265
+
+Source-agnostic identifiers for ingestion_jobs.
+
+Adds ``external_id`` and ``fingerprint`` columns to ``ingestion_jobs``.
+Existing rows are backfilled from the legacy ``file_path`` /
+``file_size`` / ``file_mtime_ns`` columns so the new fingerprint string
+matches what ``LocalFileSource.fingerprint()`` produces today
+(``json({"size": ..., "mtime_ns": ...})``). The legacy columns are
+kept while callers transition off them and will be dropped in a
+follow-up migration.
+
+DB engine: SQLite. ``json_object()`` is SQLite syntax — if the project
+gains a Postgres target, this migration's backfill needs a dialect
+branch (``jsonb_build_object``).
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+import sqlmodel  # Added for SQLModel support
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d9b3cb044bc7"
+down_revision: str | None = "b2f4a3c7e108"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "ingestion_jobs",
+        sa.Column("external_id", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    )
+    op.add_column(
+        "ingestion_jobs",
+        sa.Column("fingerprint", sqlmodel.sql.sqltypes.AutoString(), nullable=True),
+    )
+
+    # Backfill: external_id from file_path; fingerprint from the
+    # LocalFileSource.fingerprint() JSON shape.
+    op.execute(
+        """
+        UPDATE ingestion_jobs
+        SET external_id = file_path,
+            fingerprint = json_object('size', file_size, 'mtime_ns', file_mtime_ns)
+        WHERE external_id IS NULL
+        """
+    )
+
+    op.create_index(
+        op.f("ix_ingestion_jobs_external_id"),
+        "ingestion_jobs",
+        ["external_id"],
+        unique=False,
+    )
+    # Non-unique during the dual-write transition. A follow-up migration
+    # drops the legacy (dataset_id, file_path) unique constraint and
+    # promotes this index to UNIQUE.
+    op.create_index(
+        "idx_ingestion_job_dataset_external",
+        "ingestion_jobs",
+        ["dataset_id", "external_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_ingestion_job_dataset_external", table_name="ingestion_jobs")
+    op.drop_index(op.f("ix_ingestion_jobs_external_id"), table_name="ingestion_jobs")
+    op.drop_column("ingestion_jobs", "fingerprint")
+    op.drop_column("ingestion_jobs", "external_id")

--- a/backend/syft_space/components/ingestion/entities.py
+++ b/backend/syft_space/components/ingestion/entities.py
@@ -19,18 +19,21 @@ class IngestionJobStatus(str, Enum):
 
 
 class IngestionJob(SQLModel, table=True):
-    """Tracks individual file ingestion status for a dataset.
+    """Tracks individual item ingestion status for a dataset.
 
-    Each job represents one file's ingestion state. Jobs are created when:
-    - Dataset ingestion is started (initial scan of existing files)
-    - File watcher detects new/modified files
+    Each job represents one source item's ingestion state. Jobs are created when:
+    - Dataset ingestion is started (initial scan of existing items)
+    - Source change_stream emits a created/updated event
 
-    Fingerprint (size, mtime_ns) determines if re-ingestion is needed.
+    The opaque ``fingerprint`` string (source-defined) is compared for
+    equality to decide whether re-ingestion is needed.
     """
 
     __tablename__ = "ingestion_jobs"
     __table_args__ = (
-        # Unique constraint: one job per file path per dataset
+        # Deprecated uniqueness on (dataset_id, file_path). Will be
+        # replaced by (dataset_id, external_id) once the legacy file_*
+        # columns are dropped.
         UniqueConstraint(
             "dataset_id", "file_path", name="uq_ingestion_job_dataset_file"
         ),
@@ -38,6 +41,9 @@ class IngestionJob(SQLModel, table=True):
         Index("idx_ingestion_job_tenant_status", "tenant_id", "status"),
         # Index for dataset lookups
         Index("idx_ingestion_job_dataset_id", "dataset_id"),
+        # Source-agnostic lookup path. Non-unique during the dual-write
+        # transition; promoted to UNIQUE once file_path is dropped.
+        Index("idx_ingestion_job_dataset_external", "dataset_id", "external_id"),
     )
 
     id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
@@ -56,11 +62,26 @@ class IngestionJob(SQLModel, table=True):
         description="Dataset this job belongs to",
     )
 
-    # File identification
+    # Source-agnostic identifiers.
+    # ``external_id`` is the source-unique opaque key (filesystem path,
+    # WP post id, RSS guid, S3 key, ...). ``fingerprint`` is the
+    # source-controlled change-detection token compared as an opaque
+    # string. Both are nullable during the dual-write transition; they
+    # will become NOT NULL once the legacy file_* columns are dropped.
+    external_id: str | None = Field(
+        default=None,
+        index=True,
+        description="Source-unique identifier (path, post id, guid, ...)",
+    )
+    fingerprint: str | None = Field(
+        default=None,
+        description="Source-defined change-detection token (opaque)",
+    )
+
+    # Deprecated file_*-specific columns. Populated by dual-write
+    # alongside external_id/fingerprint until they're dropped.
     file_path: str = Field(..., description="Absolute path to the file")
     file_name: str = Field(..., description="File name (basename)")
-
-    # Fingerprint for change detection (fast, no content hashing)
     file_size: int = Field(..., description="File size in bytes")
     file_mtime_ns: int = Field(..., description="File modification time in nanoseconds")
 

--- a/backend/syft_space/components/ingestion/manager.py
+++ b/backend/syft_space/components/ingestion/manager.py
@@ -265,30 +265,42 @@ class IngestionManager(LifecycleService):
         self, dataset_id: UUID, tenant_id: UUID, event: SourceChangeEvent
     ) -> None:
         if event.event_type == "deleted":
-            await self._ingestion_repository.delete_by_path(
+            await self._ingestion_repository.delete_by_external_id(
                 dataset_id, event.external_id
             )
             return
 
-        # PR 4 generalizes IngestionJob to carry external_id + opaque
-        # fingerprint instead of file_size/file_mtime_ns columns. Until
-        # then, decode the local-file fingerprint shape here so existing
-        # columns stay populated.
-        try:
-            fp_data = json.loads(event.fingerprint) if event.fingerprint else {}
-        except (json.JSONDecodeError, TypeError):
-            fp_data = {}
-
-        await self._ingestion_repository.upsert_by_path(
+        file_size, file_mtime_ns = self._derive_legacy_file_fields(event.fingerprint)
+        await self._ingestion_repository.upsert_by_external_id(
             tenant_id=tenant_id,
             dataset_id=dataset_id,
+            external_id=event.external_id,
+            fingerprint=event.fingerprint,
+            # Deprecated dual-write — will be removed with the legacy columns.
             file_path=event.external_id,
             file_name=SyncPath(event.external_id).name,
-            file_size=int(fp_data.get("size", 0)),
-            file_mtime_ns=int(fp_data.get("mtime_ns", 0)),
+            file_size=file_size,
+            file_mtime_ns=file_mtime_ns,
         )
         if self._job_signal is not None:
             self._job_signal.set()
+
+    @staticmethod
+    def _derive_legacy_file_fields(fingerprint: str | None) -> tuple[int, int]:
+        """Decode the LocalFileSource fingerprint into ``(size, mtime_ns)``.
+
+        Transitional dual-write helper. ``fingerprint`` is the canonical
+        change-detection token; the deprecated ``file_size`` /
+        ``file_mtime_ns`` columns still need values until they're
+        dropped. Non-decodable fingerprints (non-filesystem sources)
+        get zeros — those rows never reach chunking, since their
+        dataset_type is the consumer.
+        """
+        try:
+            data = json.loads(fingerprint) if fingerprint else {}
+        except (json.JSONDecodeError, TypeError):
+            data = {}
+        return int(data.get("size", 0)), int(data.get("mtime_ns", 0))
 
     # -------------------------------------------------------------------------
     # Job processing
@@ -356,49 +368,53 @@ class IngestionManager(LifecycleService):
             return
         source, dataset_type = resolved
 
+        external_id = job.external_id or job.file_path
         try:
-            # Fingerprint-drift check via the source. If the file changed
-            # since the job was queued, re-upsert with the new fingerprint
-            # and cancel this one — the upsert produces a new pending job.
+            # Fingerprint-drift check via the source. Opaque string compare —
+            # if the item changed since the job was queued, re-upsert with
+            # the new fingerprint and cancel this one (the upsert produces
+            # a new pending job).
             try:
-                current_fp = source.fingerprint(job.file_path)
-                current_data = json.loads(current_fp)
-                if (
-                    current_data.get("size") != job.file_size
-                    or current_data.get("mtime_ns") != job.file_mtime_ns
-                ):
-                    logger.info(f"File changed during processing: {job.file_path}")
-                    await self._ingestion_repository.upsert_by_path(
+                current_fp = source.fingerprint(external_id)
+                if current_fp != job.fingerprint:
+                    logger.info(f"Item changed during processing: {external_id}")
+                    file_size, file_mtime_ns = self._derive_legacy_file_fields(
+                        current_fp
+                    )
+                    await self._ingestion_repository.upsert_by_external_id(
                         tenant_id=job.tenant_id,
                         dataset_id=job.dataset_id,
-                        file_path=job.file_path,
+                        external_id=external_id,
+                        fingerprint=current_fp,
+                        # Deprecated dual-write — will be removed with the legacy columns.
+                        file_path=external_id,
                         file_name=job.file_name,
-                        file_size=int(current_data["size"]),
-                        file_mtime_ns=int(current_data["mtime_ns"]),
+                        file_size=file_size,
+                        file_mtime_ns=file_mtime_ns,
                     )
                     await self._ingestion_repository.update_status(
                         job.id,
                         IngestionJobStatus.CANCELLED,
-                        "File changed during processing",
+                        "Item changed during processing",
                     )
                     return
             except FileNotFoundError:
                 await self._ingestion_repository.update_status(
                     job.id,
                     IngestionJobStatus.CANCELLED,
-                    "File no longer exists",
+                    "Item no longer exists",
                 )
                 return
-            except (json.JSONDecodeError, OSError) as e:
+            except OSError as e:
                 # Best-effort: if we can't re-fingerprint, proceed with ingestion.
-                logger.debug(f"Fingerprint recheck failed for {job.file_path}: {e}")
+                logger.debug(f"Fingerprint recheck failed for {external_id}: {e}")
 
             await self._ingestion_repository.update_status(
                 job.id, IngestionJobStatus.IN_PROGRESS
             )
 
             try:
-                async with source.fetch(job.file_path) as ingest_file:
+                async with source.fetch(external_id) as ingest_file:
                     # TOCTOU re-check on the dataset row (could have been
                     # deleted mid-fetch).
                     dataset = await self._dataset_repository.get_by_id(
@@ -434,10 +450,10 @@ class IngestionManager(LifecycleService):
             await self._ingestion_repository.update_status(
                 job.id, IngestionJobStatus.COMPLETED
             )
-            logger.info(f"Successfully ingested: {job.file_path}")
+            logger.info(f"Successfully ingested: {external_id}")
 
         except Exception as e:
-            logger.exception(f"Failed to ingest {job.file_path}: {e}")
+            logger.exception(f"Failed to ingest {external_id}: {e}")
             await self._ingestion_repository.update_status(
                 job.id, IngestionJobStatus.FAILED, str(e)
             )

--- a/backend/syft_space/components/ingestion/repository.py
+++ b/backend/syft_space/components/ingestion/repository.py
@@ -15,7 +15,9 @@ class IngestionJobRepository(AsyncBaseRepository[IngestionJob]):
     """Repository for IngestionJob CRUD operations.
 
     Key operations:
-    - upsert_by_path(): Create or update job by file path (for watcher events)
+    - upsert_by_external_id(): Create or update job by source-unique id
+      (for source change-stream events)
+    - get_by_external_id(): Lookup by source-unique id
     - get_pending_jobs(): Get jobs ready for processing
     - get_by_dataset(): Get all jobs for a dataset
     - update_status(): Update job status with timestamps
@@ -31,38 +33,39 @@ class IngestionJobRepository(AsyncBaseRepository[IngestionJob]):
         """
         super().__init__(db, IngestionJob)
 
-    async def upsert_by_path(
+    async def upsert_by_external_id(
         self,
+        *,
         tenant_id: UUID,
         dataset_id: UUID,
+        external_id: str,
+        fingerprint: str | None,
         file_path: str,
         file_name: str,
         file_size: int,
         file_mtime_ns: int,
     ) -> IngestionJob:
-        """Create or update an ingestion job by file path.
+        """Create or update an ingestion job by source-unique id.
 
         Logic:
-        - If job exists with same fingerprint AND status == COMPLETED → no change (skip)
-        - If job exists with different fingerprint OR status != COMPLETED → reset to PENDING
-        - If job doesn't exist → create PENDING job
+        - Existing row with matching ``fingerprint`` AND status == COMPLETED → skip.
+        - Existing row with different fingerprint OR not completed → reset to PENDING.
+        - No existing row → create PENDING.
 
-        Args:
-            tenant_id: Tenant UUID
-            dataset_id: Dataset UUID
-            file_path: Absolute file path
-            file_name: File basename
-            file_size: Size in bytes
-            file_mtime_ns: Modification time in nanoseconds
+        The fingerprint comparison is an opaque string equality check —
+        sources define the format (see ``BaseSource.fingerprint``); the
+        repository treats it as a blob.
 
-        Returns:
-            Created or updated IngestionJob
+        ``file_path`` / ``file_name`` / ``file_size`` / ``file_mtime_ns`` are
+        deprecated columns dual-written alongside ``external_id`` /
+        ``fingerprint`` and derived by the caller from the source event.
+        They will be dropped once nothing reads from them.
         """
         async with self.db.get_session() as session:
             result = await session.exec(
                 select(IngestionJob).where(
                     IngestionJob.dataset_id == dataset_id,
-                    IngestionJob.file_path == file_path,
+                    IngestionJob.external_id == external_id,
                 )
             )
             existing = result.first()
@@ -70,22 +73,17 @@ class IngestionJobRepository(AsyncBaseRepository[IngestionJob]):
             now = datetime.now(timezone.utc)
 
             if existing:
-                # Check if fingerprint unchanged AND already completed
-                fingerprint_unchanged = (
-                    existing.file_size == file_size
-                    and existing.file_mtime_ns == file_mtime_ns
-                )
                 if (
-                    fingerprint_unchanged
+                    existing.fingerprint == fingerprint
                     and existing.status == IngestionJobStatus.COMPLETED.value
                 ):
-                    # No change needed, file already ingested with same fingerprint
                     logger.info(
-                        f"File {file_path} already ingested with same fingerprint"
+                        f"Item {external_id} already ingested with same fingerprint"
                     )
                     return existing
 
-                # Fingerprint changed or not completed - reset to pending
+                existing.fingerprint = fingerprint
+                # Deprecated dual-write — will be removed with the legacy columns.
                 existing.file_size = file_size
                 existing.file_mtime_ns = file_mtime_ns
                 existing.status = IngestionJobStatus.PENDING.value
@@ -100,10 +98,12 @@ class IngestionJobRepository(AsyncBaseRepository[IngestionJob]):
                 await session.refresh(existing)
                 return existing
             else:
-                # Create new job
                 job = IngestionJob(
                     tenant_id=tenant_id,
                     dataset_id=dataset_id,
+                    external_id=external_id,
+                    fingerprint=fingerprint,
+                    # Deprecated dual-write — will be removed with the legacy columns.
                     file_path=file_path,
                     file_name=file_name,
                     file_size=file_size,
@@ -116,6 +116,19 @@ class IngestionJobRepository(AsyncBaseRepository[IngestionJob]):
                 await session.commit()
                 await session.refresh(job)
                 return job
+
+    async def get_by_external_id(
+        self, dataset_id: UUID, external_id: str
+    ) -> IngestionJob | None:
+        """Return the job for ``(dataset_id, external_id)`` if any."""
+        async with self.db.get_session() as session:
+            result = await session.exec(
+                select(IngestionJob).where(
+                    IngestionJob.dataset_id == dataset_id,
+                    IngestionJob.external_id == external_id,
+                )
+            )
+            return result.first()
 
     async def get_pending_jobs(
         self,
@@ -291,21 +304,16 @@ class IngestionJobRepository(AsyncBaseRepository[IngestionJob]):
             await session.commit()
             return count
 
-    async def delete_by_path(self, dataset_id: UUID, file_path: str) -> bool:
-        """Delete a job by file path (for file deletion events).
+    async def delete_by_external_id(self, dataset_id: UUID, external_id: str) -> bool:
+        """Delete a job by source-unique id (for source ``deleted`` events).
 
-        Args:
-            dataset_id: Dataset UUID
-            file_path: File path to delete
-
-        Returns:
-            True if deleted, False if not found
+        Returns True if a row was deleted, False if no match.
         """
         async with self.db.get_session() as session:
             result = await session.exec(
                 select(IngestionJob).where(
                     IngestionJob.dataset_id == dataset_id,
-                    IngestionJob.file_path == file_path,
+                    IngestionJob.external_id == external_id,
                 )
             )
             job = result.first()

--- a/backend/syft_space/components/ingestion/schemas.py
+++ b/backend/syft_space/components/ingestion/schemas.py
@@ -10,6 +10,12 @@ class IngestionJobResponse(BaseModel):
     """Response model for a single ingestion job."""
 
     id: UUID = Field(..., description="Job UUID")
+    external_id: str | None = Field(
+        None, description="Source-unique identifier (path, post id, guid, ...)"
+    )
+    fingerprint: str | None = Field(
+        None, description="Source-defined change-detection token (opaque)"
+    )
     file_path: str = Field(..., description="Absolute file path")
     file_name: str = Field(..., description="File name")
     file_size: int = Field(..., description="File size in bytes")

--- a/backend/syft_space/components/sources/local_file/local_file_source.py
+++ b/backend/syft_space/components/sources/local_file/local_file_source.py
@@ -161,9 +161,17 @@ class LocalFileSource:
         )
 
     def fingerprint(self, external_id: str) -> str:
-        """JSON-encoded ``{size, mtime_ns}`` token for change detection."""
+        """Compact JSON ``{size, mtime_ns}`` token for change detection.
+
+        Compact (no separator whitespace) so the string round-trips
+        byte-equal through SQLite's ``json_object()`` backfill used to
+        seed ``fingerprint`` for existing rows.
+        """
         stat = SyncPath(external_id).stat()
-        return json.dumps({"size": stat.st_size, "mtime_ns": stat.st_mtime_ns})
+        return json.dumps(
+            {"size": stat.st_size, "mtime_ns": stat.st_mtime_ns},
+            separators=(",", ":"),
+        )
 
     def change_stream(self) -> AsyncIterator[SourceChangeEvent]:
         """Async iterator of filesystem change events.


### PR DESCRIPTION
This pull request introduces a major refactor to the ingestion job tracking system, generalizing it to support source-agnostic identifiers and change detection. The core change is the addition of `external_id` and `fingerprint` fields to the `ingestion_jobs` table and related code, replacing the previous file-specific identification (`file_path`, `file_size`, `file_mtime_ns`). The update enables ingestion from non-filesystem sources and transitions all logic to use these new, opaque identifiers, while maintaining backward compatibility during migration.

**Database and Model Changes:**

- Added `external_id` (source-unique identifier) and `fingerprint` (opaque change-detection token) columns to the `ingestion_jobs` table, with a migration that backfills existing rows and creates new indexes for efficient lookup. Legacy file-specific columns are retained for now but marked as deprecated. [[1]](diffhunk://#diff-91eeb8d19dcdca1d1530ea837fa95661fea7e5fe8b36c590ee2d75df8a0a065bR1-R77) [[2]](diffhunk://#diff-7cd9f454e2e6793e719e3bcfe99315a1b3a87a9714f81a6c02850146a5faedf7L22-R46) [[3]](diffhunk://#diff-7cd9f454e2e6793e719e3bcfe99315a1b3a87a9714f81a6c02850146a5faedf7L59-L63)

**Repository and API Refactor:**

- Refactored repository methods to use `external_id` as the primary identifier for upsert, get, and delete operations, replacing file path-based methods. Added new methods: `upsert_by_external_id`, `get_by_external_id`, and `delete_by_external_id`. [[1]](diffhunk://#diff-c805ea03be3097203bc3c48de744bc0766747a0621b5eb1bc19b23e38ca9cb70L18-R20) [[2]](diffhunk://#diff-c805ea03be3097203bc3c48de744bc0766747a0621b5eb1bc19b23e38ca9cb70L34-R86) [[3]](diffhunk://#diff-c805ea03be3097203bc3c48de744bc0766747a0621b5eb1bc19b23e38ca9cb70L103-R106) [[4]](diffhunk://#diff-c805ea03be3097203bc3c48de744bc0766747a0621b5eb1bc19b23e38ca9cb70R120-R132) [[5]](diffhunk://#diff-c805ea03be3097203bc3c48de744bc0766747a0621b5eb1bc19b23e38ca9cb70L294-R316)
- Updated the API response model to include `external_id` and `fingerprint` fields.

**Ingestion Logic Updates:**

- Updated the ingestion manager to use `external_id` and `fingerprint` for all job operations, including event handling and job processing. Introduced a helper to decode legacy file fields from the fingerprint for dual-write compatibility. [[1]](diffhunk://#diff-bb6544adee11292ea3bb6233620c11d55f30350552edeba9acb5a028d43050cbL268-R304) [[2]](diffhunk://#diff-bb6544adee11292ea3bb6233620c11d55f30350552edeba9acb5a028d43050cbR371-R417) [[3]](diffhunk://#diff-bb6544adee11292ea3bb6233620c11d55f30350552edeba9acb5a028d43050cbL437-R456)

**Source Abstraction Improvements:**

- Standardized the fingerprint format in `LocalFileSource` to ensure byte-equal round-trips for migration and future compatibility.

---

**Database and Model Changes**
- Added `external_id` and `fingerprint` columns to `ingestion_jobs`, with migration and backfill logic; created new indexes for source-agnostic lookups; legacy file-specific columns are now deprecated and will be removed in a future migration. [[1]](diffhunk://#diff-91eeb8d19dcdca1d1530ea837fa95661fea7e5fe8b36c590ee2d75df8a0a065bR1-R77) [[2]](diffhunk://#diff-7cd9f454e2e6793e719e3bcfe99315a1b3a87a9714f81a6c02850146a5faedf7L22-R46) [[3]](diffhunk://#diff-7cd9f454e2e6793e719e3bcfe99315a1b3a87a9714f81a6c02850146a5faedf7L59-L63)

**Repository and API Refactor**
- Introduced repository methods for upsert, get, and delete by `external_id` instead of file path, and updated the API response to include the new fields. [[1]](diffhunk://#diff-c805ea03be3097203bc3c48de744bc0766747a0621b5eb1bc19b23e38ca9cb70L18-R20) [[2]](diffhunk://#diff-c805ea03be3097203bc3c48de744bc0766747a0621b5eb1bc19b23e38ca9cb70L34-R86) [[3]](diffhunk://#diff-c805ea03be3097203bc3c48de744bc0766747a0621b5eb1bc19b23e38ca9cb70L103-R106) [[4]](diffhunk://#diff-c805ea03be3097203bc3c48de744bc0766747a0621b5eb1bc19b23e38ca9cb70R120-R132) [[5]](diffhunk://#diff-c805ea03be3097203bc3c48de744bc0766747a0621b5eb1bc19b23e38ca9cb70L294-R316) [[6]](diffhunk://#diff-1bfbfbd3499eec450f3ed22acaa0ae92dbe4e0b0bbd4ca4a224340f09ee024faR13-R18)

**Ingestion Logic Updates**
- Refactored ingestion manager logic to use `external_id` and `fingerprint` for all job lifecycle operations, including event handling, job processing, and status updates; added a helper for legacy field decoding. [[1]](diffhunk://#diff-bb6544adee11292ea3bb6233620c11d55f30350552edeba9acb5a028d43050cbL268-R304) [[2]](diffhunk://#diff-bb6544adee11292ea3bb6233620c11d55f30350552edeba9acb5a028d43050cbR371-R417) [[3]](diffhunk://#diff-bb6544adee11292ea3bb6233620c11d55f30350552edeba9acb5a028d43050cbL437-R456)

**Source Abstraction Improvements**
- Ensured that `LocalFileSource.fingerprint()` produces compact JSON for compatibility with the migration and consistent change detection.