### PR TITLE
feat(endpoints): policy_metadata envelope on query responses (OME-285)

### DIFF
--- a/backend/docs/payments.md
+++ b/backend/docs/payments.md
@@ -90,7 +90,7 @@ sequenceDiagram
     C->>SS: POST /{slug}/query (X-Payment: signed)
     SS->>T: verify / settle payment
     SS->>SS: run RAG pipeline
-    SS-->>C: 200 + Payment-Receipt header
+    SS-->>C: 200 + policy_metadata (charge, tx id, recipient)
 ```
 
 If the response turns out empty, the post-hook avoids charging. Balance and
@@ -123,6 +123,17 @@ sequenceDiagram
 Users can inspect their own balance/invoices/transactions through the public
 `/payments/gateway/wallets/{id}/…/me` routes; owners get tenant-wide views under
 the admin-only `/payments/gateway/…` routes.
+
+## What the caller sees per query
+
+Charges are reported in the query response itself, not via headers. Every
+response carries a `policy_metadata` envelope with one entry per policy; a
+payment entry records its `status` (`charged` / `refunded` / `free`), the
+`amount`/`currency`, the `recipient`, and the rail-native `transaction` id
+(Tempo tx hash for MPP, ledger UUID for prepaid). When a payment policy blocks
+the query, the same envelope rides the `402`/`403` with a `reason_code`
+(e.g. `PAYMENT_REQUIRED`, `INSUFFICIENT_BALANCE`) and human-readable `reason`.
+See [Query Flow](./query-flow.md#9-response) for the full shape.
 
 ## Wallet deletion guard
 

--- a/backend/docs/query-flow.md
+++ b/backend/docs/query-flow.md
@@ -26,14 +26,14 @@ sequenceDiagram
     Q->>Q: load policies + inject wallet credentials
     Q->>POL: pre-hooks (access, rate_limit, payment)
     alt blocked
-        POL-->>C: 403 (denied / rate limited) or 402 (payment required)
+        POL-->>C: 402/403 + policy_metadata (reason_code, reason)
     end
     POL->>DS: search (if raw/both)
     DS->>MD: inject top hits as context (if both)
     MD->>POL2: response
     POL2->>POL2: post-hooks (settle payment, record usage)
     Q->>AN: fire-and-forget query event
-    Q-->>C: 200 { summary?, references? }
+    Q-->>C: 200 { summary?, references?, policy_metadata }
 ```
 
 ## Step by step
@@ -108,9 +108,10 @@ Branches on `endpoint.response_type`:
 
 `post_hook` runs for each policy type with both request and response available:
 
-- **Payment** policies settle the charge — add the cost (and an MPP
-  `Payment-Receipt` header), or **cancel the reservation** if the response was
-  empty (no summary, no documents), so callers aren't billed for nothing.
+- **Payment** policies settle the charge — record what was charged, to whom, and
+  the rail-native transaction id in `policy_metadata`, or **cancel the
+  reservation** if the response was empty (no summary, no documents), so callers
+  aren't billed for nothing.
 - Other policies record usage / audit as needed. A post-hook can still block.
 
 ### 8. Analytics
@@ -125,11 +126,38 @@ is drained on shutdown.
 // 200 OK
 {
   "summary":    { /* LLM answer, usage, cost */ } /* present for summary|both */,
-  "references": { /* documents[], provider_info */ } /* present for raw|both */
+  "references": { /* documents[], provider_info */ } /* present for raw|both */,
+  "policy_metadata": { /* see below */ }
 }
 ```
 
+Every query response — success **and** rejection — carries a `policy_metadata`
+envelope, the authoritative record of what each policy did. Clients read it
+instead of reconstructing price/recipient from policy config:
+
+```jsonc
+{
+  "outcome": "success",          // or payment_required / rate_limited / access_denied / ...
+  "entries": [
+    {
+      "policy_type": "mpp_per_request",
+      "kind":   "payment",       // payment | access | transform | rate_limit
+      "status": "charged",       // charged | refunded | free | rejected | applied | skipped
+      "amount": 0.01, "currency": "USD",
+      "recipient":   { "username": "...", "wallet_address": "..." },
+      "transaction": { "rail": "mpp", "id": "0x…" },
+      "reason_code": null,       // e.g. INSUFFICIENT_BALANCE / RATE_LIMITED when rejected
+      "reason":      null        // human-readable explanation when rejected
+    }
+  ]
+}
+```
+
+On a block, the route returns `402`/`403` with the **same** envelope (plus a
+`detail` message), so a rejection's `reason_code`/`reason` explain *why* in the
+body, not just the status code.
+
 For the precise field set, see `POST /endpoints/{slug}/query` in `/docs`. For
-the payment-specific exchanges (challenge, receipt, prepaid settlement) see
+the payment-specific exchanges (challenge, prepaid settlement) see
 [Payments & Wallets](./payments.md).
 </content>

--- a/backend/syft_space/components/endpoints/interfaces.py
+++ b/backend/syft_space/components/endpoints/interfaces.py
@@ -30,6 +30,8 @@ class QueryOutcome(str, Enum):
     NOT_PUBLISHED = "not_published"
     PAYMENT_REQUIRED = "payment_required"
     POLICY_VIOLATION = "policy_violation"
+    ACCESS_DENIED = "access_denied"
+    RATE_LIMITED = "rate_limited"
     INTERNAL_ERROR = "internal_error"
 
 

--- a/backend/syft_space/components/endpoints/query_handler.py
+++ b/backend/syft_space/components/endpoints/query_handler.py
@@ -19,6 +19,7 @@ from syft_space.components.endpoints.schemas import (
     AuthenticatedQueryRequest,
     DocumentResponse,
     MessageResponse,
+    PolicyMetadata,
     ProviderInfo,
     QueryEndpointResponse,
     ReferencesResponse,
@@ -38,9 +39,8 @@ from syft_space.components.policies.repository import PolicyRepository
 from syft_space.components.policy_types.interfaces import (
     PaymentRequiredError,
     PolicyContext,
-    PolicyMetadata,
+    PolicyMetadataEntry,
     PolicyViolationError,
-    QueryRejectedError,
     Recipient,
 )
 from syft_space.components.policy_types.registry import PolicyTypeRegistry
@@ -48,6 +48,82 @@ from syft_space.components.shared.search_types import SearchContext, SearchParam
 from syft_space.components.tenants.entities import Tenant
 from syft_space.components.wallets.entities import Wallet
 from syft_space.components.wallets.repository import WalletRepository
+
+
+class QueryRejectedError(Exception):
+    """A query was rejected by a policy (payment/access/rate-limit).
+
+    Carries everything the route needs to render the rejection body with the
+    same `policy_metadata` envelope as a successful response. Built by the
+    query handler from PaymentRequiredError / PolicyViolationError so the route
+    has a single rejection branch. Lives in the endpoints layer because it
+    carries the HTTP status_code/headers the adapter renders.
+    """
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        detail: str,
+        policy_metadata: PolicyMetadata,
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.detail = detail
+        self.policy_metadata = policy_metadata
+        self.headers = headers
+        super().__init__(detail)
+
+    @staticmethod
+    def _envelope_entries(
+        prior_entries: list[PolicyMetadataEntry] | None,
+        rejecting_entry: PolicyMetadataEntry | None,
+    ) -> list[PolicyMetadataEntry]:
+        """Entries from policies that already ran (e.g. an earlier charge),
+        followed by the rejecting policy's own entry — so a chain like
+        "policy A charged, policy B rejected" surfaces both, not just B.
+        """
+        entries = list(prior_entries or [])
+        if rejecting_entry is not None:
+            entries.append(rejecting_entry)
+        return entries
+
+    @classmethod
+    def from_violation(
+        cls,
+        e: PolicyViolationError,
+        prior_entries: list[PolicyMetadataEntry] | None = None,
+    ) -> "QueryRejectedError":
+        """Build a 403 rejection carrying the policy_metadata envelope.
+
+        `QueryOutcome` is a value-superset of `PolicyRejection`, so coercing the
+        rejection to its outcome by value always succeeds.
+        """
+        return cls(
+            status_code=403,
+            detail=f"Policy '{e.policy_type}' blocked request: {e.details}",
+            policy_metadata=PolicyMetadata(
+                outcome=QueryOutcome(e.outcome.value),
+                entries=cls._envelope_entries(prior_entries, e.metadata_entry),
+            ),
+        )
+
+    @classmethod
+    def from_payment(
+        cls,
+        e: PaymentRequiredError,
+        prior_entries: list[PolicyMetadataEntry] | None = None,
+    ) -> "QueryRejectedError":
+        """Build a 402 rejection carrying the policy_metadata envelope."""
+        return cls(
+            status_code=402,
+            detail=e.description or "Payment required",
+            policy_metadata=PolicyMetadata(
+                outcome=QueryOutcome.PAYMENT_REQUIRED,
+                entries=cls._envelope_entries(prior_entries, e.metadata_entry),
+            ),
+            headers={"WWW-Authenticate": e.www_authenticate},
+        )
 
 
 class QueryEndpointHandler:
@@ -100,6 +176,9 @@ class QueryEndpointHandler:
         endpoint: Endpoint | None = None
         outcome: QueryOutcome = QueryOutcome.SUCCESS
         final_response: QueryEndpointResponse | None = None
+        # Set once the context exists; lets the rejection branches surface
+        # entries from policies that already ran before the block.
+        policy_context: PolicyContext | None = None
 
         try:
             endpoint = await self.endpoint_repository.get_by_slug(slug, tenant.id)
@@ -234,7 +313,7 @@ class QueryEndpointHandler:
             # Attach the success policy_metadata envelope onto the response.
             response_dict = policy_context.response or {}
             response_dict["policy_metadata"] = PolicyMetadata(
-                outcome=QueryOutcome.SUCCESS.value,
+                outcome=QueryOutcome.SUCCESS,
                 entries=policy_context.policy_metadata,
             ).model_dump()
 
@@ -243,11 +322,13 @@ class QueryEndpointHandler:
 
         except PolicyViolationError as e:
             # A policy blocked the request from any point in the pipeline.
-            outcome = self._safe_outcome(e.outcome)
-            raise self._reject_violation(e) from e
+            outcome = QueryOutcome(e.outcome.value)
+            prior = policy_context.policy_metadata if policy_context else None
+            raise QueryRejectedError.from_violation(e, prior) from e
         except PaymentRequiredError as e:
             outcome = QueryOutcome.PAYMENT_REQUIRED
-            raise self._reject_payment(e) from e
+            prior = policy_context.policy_metadata if policy_context else None
+            raise QueryRejectedError.from_payment(e, prior) from e
         except HTTPException:
             if outcome == QueryOutcome.SUCCESS:
                 outcome = QueryOutcome.INTERNAL_ERROR
@@ -302,43 +383,6 @@ class QueryEndpointHandler:
         if not (username or email or wallet_address):
             return None
         return Recipient(username=username, email=email, wallet_address=wallet_address)
-
-    @staticmethod
-    def _safe_outcome(outcome: str) -> QueryOutcome:
-        """Map a policy's outcome string to a QueryOutcome, never raising.
-
-        A policy may supply any string; an unrecognized value falls back to
-        POLICY_VIOLATION so a deliberate rejection is never masked as a 500.
-        """
-        try:
-            return QueryOutcome(outcome)
-        except ValueError:
-            return QueryOutcome.POLICY_VIOLATION
-
-    def _reject_violation(self, e: PolicyViolationError) -> QueryRejectedError:
-        """Build a 403 rejection carrying the policy_metadata envelope."""
-        entry = e.metadata_entry
-        return QueryRejectedError(
-            status_code=403,
-            detail=f"Policy '{e.policy_type}' blocked request: {e.details}",
-            policy_metadata=PolicyMetadata(
-                outcome=e.outcome,
-                entries=[entry] if entry else [],
-            ),
-        )
-
-    def _reject_payment(self, e: PaymentRequiredError) -> QueryRejectedError:
-        """Build a 402 rejection carrying the policy_metadata envelope."""
-        entry = e.metadata_entry
-        return QueryRejectedError(
-            status_code=402,
-            detail=e.description or "Payment required",
-            policy_metadata=PolicyMetadata(
-                outcome=QueryOutcome.PAYMENT_REQUIRED.value,
-                entries=[entry] if entry else [],
-            ),
-            headers={"WWW-Authenticate": e.www_authenticate},
-        )
 
     async def _search_dataset(
         self,

--- a/backend/syft_space/components/endpoints/query_handler.py
+++ b/backend/syft_space/components/endpoints/query_handler.py
@@ -25,6 +25,7 @@ from syft_space.components.endpoints.schemas import (
     SummaryResponse,
     TokenUsage,
 )
+from syft_space.components.marketplaces.repository import MarketplaceRepository
 from syft_space.components.model_types.interfaces import (
     ChatContext,
     ChatMessage,
@@ -37,7 +38,10 @@ from syft_space.components.policies.repository import PolicyRepository
 from syft_space.components.policy_types.interfaces import (
     PaymentRequiredError,
     PolicyContext,
+    PolicyMetadata,
     PolicyViolationError,
+    QueryRejectedError,
+    Recipient,
 )
 from syft_space.components.policy_types.registry import PolicyTypeRegistry
 from syft_space.components.shared.search_types import SearchContext, SearchParameters
@@ -61,6 +65,7 @@ class QueryEndpointHandler:
         wallet_repository: WalletRepository | None = None,
         balance_service: BalanceService | None = None,
         event_reporter: QueryEventReporter | None = None,
+        marketplace_repository: MarketplaceRepository | None = None,
     ):
         self.endpoint_repository = endpoint_repository
         self.dataset_repository = dataset_repository
@@ -72,6 +77,7 @@ class QueryEndpointHandler:
         self.wallet_repository = wallet_repository
         self.balance_service = balance_service
         self.event_reporter = event_reporter
+        self.marketplace_repository = marketplace_repository
 
     async def query_endpoint(
         self,
@@ -79,15 +85,17 @@ class QueryEndpointHandler:
         request: AuthenticatedQueryRequest,
         tenant: Tenant,
         x_payment: str | None = None,
-    ) -> tuple[QueryEndpointResponse, str | None]:
+    ) -> QueryEndpointResponse:
         """Query an endpoint - main RAG flow.
 
         Returns:
-            Tuple of (query response, payment_receipt_header or None)
+            The query response, including `policy_metadata` describing what
+            each policy charged, to whom, and the rail-native transaction id.
 
         Raises:
             HTTPException: If endpoint not found or query fails
-            PaymentRequiredError: If MPP payment is required (caller returns 402)
+            QueryRejectedError: If a policy blocked the query (payment/access/
+                rate-limit); the route renders it as 402/403 with metadata.
         """
         endpoint: Endpoint | None = None
         outcome: QueryOutcome = QueryOutcome.SUCCESS
@@ -142,32 +150,32 @@ class QueryEndpointHandler:
                 x_payment=x_payment,
             )
 
+            # Resolve the recipient ("to whom") once, only when a wallet is
+            # attached. Recipient is read solely by payment-policy metadata,
+            # and payment policies require a wallet, so non-paid endpoints skip
+            # the marketplace lookup entirely (no DB hit on the free hot path).
+            recipient = (
+                await self._resolve_recipient(tenant, wallet)
+                if wallet is not None
+                else None
+            )
+
             # Create policy context with verified sender email
             policy_context = PolicyContext(
                 endpoint_slug=slug,
                 sender_email=request.sender_email,
                 request=request.model_dump(),
                 payment_chargers=payment_chargers,
+                recipient=recipient,
             )
 
-            # Apply pre-hooks per type (one instance per type, all configs passed)
-            # Note: PaymentRequiredError is intentionally NOT caught here -
-            # it propagates to the route handler which returns HTTP 402.
+            # Apply pre-hooks per type (one instance per type, all configs passed).
+            # PolicyViolationError (403) / PaymentRequiredError (402) raised from
+            # anywhere in this body are converted once in the outer handler.
             for policy_type_name, configs in configs_by_type.items():
-                try:
-                    policy_type_cls = self.policy_registry.get_policy_type(
-                        policy_type_name
-                    )
-                    policy_instance = policy_type_cls()
-                    policy_context = await policy_instance.pre_hook(
-                        configs, policy_context
-                    )
-                except PolicyViolationError as e:
-                    outcome = QueryOutcome.POLICY_VIOLATION
-                    raise HTTPException(
-                        status_code=403,
-                        detail=f"Policy '{e.policy_type}' blocked request: {e.details}",
-                    ) from e
+                policy_type_cls = self.policy_registry.get_policy_type(policy_type_name)
+                policy_instance = policy_type_cls()
+                policy_context = await policy_instance.pre_hook(configs, policy_context)
 
             # Execute query based on response_type
             references: ReferencesResponse | None = None
@@ -217,32 +225,29 @@ class QueryEndpointHandler:
 
             # Apply post-hooks per type
             for policy_type_name, configs in configs_by_type.items():
-                try:
-                    policy_type_cls = self.policy_registry.get_policy_type(
-                        policy_type_name
-                    )
-                    policy_instance = policy_type_cls()
-                    policy_context = await policy_instance.post_hook(
-                        configs, policy_context
-                    )
-                except PolicyViolationError as e:
-                    outcome = QueryOutcome.POLICY_VIOLATION
-                    raise HTTPException(
-                        status_code=403,
-                        detail=f"Policy '{e.policy_type}' blocked request: {e.details}",
-                    ) from e
+                policy_type_cls = self.policy_registry.get_policy_type(policy_type_name)
+                policy_instance = policy_type_cls()
+                policy_context = await policy_instance.post_hook(
+                    configs, policy_context
+                )
 
-            # Extract payment receipt header if present (set by MPP payment policy post-hook)
-            payment_receipt = policy_context.metadata.get("payment_receipt_header")
+            # Attach the success policy_metadata envelope onto the response.
+            response_dict = policy_context.response or {}
+            response_dict["policy_metadata"] = PolicyMetadata(
+                outcome=QueryOutcome.SUCCESS.value,
+                entries=policy_context.policy_metadata,
+            ).model_dump()
 
-            final_response = QueryEndpointResponse.model_validate(
-                policy_context.response
-            )
-            return final_response, payment_receipt
+            final_response = QueryEndpointResponse.model_validate(response_dict)
+            return final_response
 
-        except PaymentRequiredError:
+        except PolicyViolationError as e:
+            # A policy blocked the request from any point in the pipeline.
+            outcome = self._safe_outcome(e.outcome)
+            raise self._reject_violation(e) from e
+        except PaymentRequiredError as e:
             outcome = QueryOutcome.PAYMENT_REQUIRED
-            raise
+            raise self._reject_payment(e) from e
         except HTTPException:
             if outcome == QueryOutcome.SUCCESS:
                 outcome = QueryOutcome.INTERNAL_ERROR
@@ -273,6 +278,67 @@ class QueryEndpointHandler:
                 except Exception:
                     # Reporter runs in `finally`; raising here would mask the user-facing exception.
                     logger.exception("event_reporter failed; continuing")
+
+    async def _resolve_recipient(
+        self, tenant: Tenant, wallet: Wallet | None
+    ) -> Recipient | None:
+        """Resolve the endpoint owner (the 'to whom') plus MPP wallet address.
+
+        Identity comes from the space's default marketplace; the public wallet
+        address is added for MPP wallets only (never a private key).
+        """
+        username: str | None = None
+        email: str | None = None
+        if self.marketplace_repository:
+            marketplace = await self.marketplace_repository.get_default(tenant.id)
+            if marketplace:
+                username = marketplace.username or None
+                email = marketplace.email or None
+
+        wallet_address: str | None = None
+        if wallet and wallet.wallet_type == "mpp":
+            wallet_address = wallet.configuration.get("wallet_address") or None
+
+        if not (username or email or wallet_address):
+            return None
+        return Recipient(username=username, email=email, wallet_address=wallet_address)
+
+    @staticmethod
+    def _safe_outcome(outcome: str) -> QueryOutcome:
+        """Map a policy's outcome string to a QueryOutcome, never raising.
+
+        A policy may supply any string; an unrecognized value falls back to
+        POLICY_VIOLATION so a deliberate rejection is never masked as a 500.
+        """
+        try:
+            return QueryOutcome(outcome)
+        except ValueError:
+            return QueryOutcome.POLICY_VIOLATION
+
+    def _reject_violation(self, e: PolicyViolationError) -> QueryRejectedError:
+        """Build a 403 rejection carrying the policy_metadata envelope."""
+        entry = e.metadata_entry
+        return QueryRejectedError(
+            status_code=403,
+            detail=f"Policy '{e.policy_type}' blocked request: {e.details}",
+            policy_metadata=PolicyMetadata(
+                outcome=e.outcome,
+                entries=[entry] if entry else [],
+            ),
+        )
+
+    def _reject_payment(self, e: PaymentRequiredError) -> QueryRejectedError:
+        """Build a 402 rejection carrying the policy_metadata envelope."""
+        entry = e.metadata_entry
+        return QueryRejectedError(
+            status_code=402,
+            detail=e.description or "Payment required",
+            policy_metadata=PolicyMetadata(
+                outcome=QueryOutcome.PAYMENT_REQUIRED.value,
+                entries=[entry] if entry else [],
+            ),
+            headers={"WWW-Authenticate": e.www_authenticate},
+        )
 
     async def _search_dataset(
         self,

--- a/backend/syft_space/components/endpoints/routes.py
+++ b/backend/syft_space/components/endpoints/routes.py
@@ -23,7 +23,7 @@ from syft_space.components.endpoints.schemas import (
     UnpublishResult,
     UpdateEndpointRequest,
 )
-from syft_space.components.policy_types.interfaces import PaymentRequiredError
+from syft_space.components.policy_types.interfaces import QueryRejectedError
 from syft_space.components.tenants.dependency import get_tenant_dependency
 from syft_space.components.tenants.entities import Tenant
 
@@ -130,24 +130,18 @@ def build_endpoint_routes(
         auth_request = AuthenticatedQueryRequest.from_request(request, sender_email)
 
         try:
-            response, payment_receipt = await handler.query_endpoint(
+            return await handler.query_endpoint(
                 slug, auth_request, tenant, x_payment=x_payment
             )
-        except PaymentRequiredError as e:
+        except QueryRejectedError as e:
             return JSONResponse(
-                status_code=402,
-                content={"detail": e.description or "Payment required"},
-                headers={"WWW-Authenticate": e.www_authenticate},
+                status_code=e.status_code,
+                content={
+                    "detail": e.detail,
+                    "policy_metadata": e.policy_metadata.model_dump(),
+                },
+                headers=e.headers,
             )
-
-        if payment_receipt:
-            return JSONResponse(
-                status_code=200,
-                content=response.model_dump(),
-                headers={"Payment-Receipt": payment_receipt},
-            )
-
-        return response
 
     @router.post("/{slug}/preview", response_model=QueryEndpointResponse)
     async def preview_endpoint(
@@ -168,24 +162,18 @@ def build_endpoint_routes(
         auth_request = AuthenticatedQueryRequest.from_request(request, sender_email)
 
         try:
-            response, payment_receipt = await qhandler.query_endpoint(
+            return await qhandler.query_endpoint(
                 slug, auth_request, tenant, x_payment=None
             )
-        except PaymentRequiredError as e:
+        except QueryRejectedError as e:
             return JSONResponse(
-                status_code=402,
-                content={"detail": e.description or "Payment required"},
-                headers={"WWW-Authenticate": e.www_authenticate},
+                status_code=e.status_code,
+                content={
+                    "detail": e.detail,
+                    "policy_metadata": e.policy_metadata.model_dump(),
+                },
+                headers=e.headers,
             )
-
-        if payment_receipt:
-            return JSONResponse(
-                status_code=200,
-                content=response.model_dump(),
-                headers={"Payment-Receipt": payment_receipt},
-            )
-
-        return response
 
     # ── Publish routes (PublishEndpointHandler) ──────────────────
 

--- a/backend/syft_space/components/endpoints/routes.py
+++ b/backend/syft_space/components/endpoints/routes.py
@@ -1,5 +1,7 @@
 """Endpoint API routes."""
 
+from typing import Any
+
 from fastapi import APIRouter, Depends, Header, HTTPException, Request
 from fastapi.responses import JSONResponse
 
@@ -7,7 +9,10 @@ from syft_space.components.auth.dependencies import get_verified_user_email
 from syft_space.components.auth.public import public_route
 from syft_space.components.endpoints.handlers import EndpointHandler
 from syft_space.components.endpoints.publish_handler import PublishEndpointHandler
-from syft_space.components.endpoints.query_handler import QueryEndpointHandler
+from syft_space.components.endpoints.query_handler import (
+    QueryEndpointHandler,
+    QueryRejectedError,
+)
 from syft_space.components.endpoints.schemas import (
     AuthenticatedQueryRequest,
     CreateEndpointRequest,
@@ -18,14 +23,29 @@ from syft_space.components.endpoints.schemas import (
     PublishEndpointResponse,
     QueryEndpointRequest,
     QueryEndpointResponse,
+    RejectionResponse,
     SlugAvailabilityRequest,
     SlugAvailabilityResponse,
     UnpublishResult,
     UpdateEndpointRequest,
 )
-from syft_space.components.policy_types.interfaces import QueryRejectedError
 from syft_space.components.tenants.dependency import get_tenant_dependency
 from syft_space.components.tenants.entities import Tenant
+
+# OpenAPI: both query routes return a RejectionResponse on 402/403, so the SDK
+# can see the rejection shape in the schema (it carries the policy_metadata).
+_REJECTION_RESPONSES: dict[int | str, dict[str, Any]] = {
+    402: {"model": RejectionResponse, "description": "Payment required"},
+    403: {"model": RejectionResponse, "description": "Blocked by a policy"},
+}
+
+
+def _render_rejection(e: QueryRejectedError) -> JSONResponse:
+    """Render a QueryRejectedError as its typed JSON body + HTTP status/headers."""
+    body = RejectionResponse(detail=e.detail, policy_metadata=e.policy_metadata)
+    return JSONResponse(
+        status_code=e.status_code, content=body.model_dump(), headers=e.headers
+    )
 
 
 def build_endpoint_routes(
@@ -117,7 +137,11 @@ def build_endpoint_routes(
     # ── Query route (QueryEndpointHandler) ───────────────────────
 
     @public_route
-    @router.post("/{slug}/query", response_model=QueryEndpointResponse)
+    @router.post(
+        "/{slug}/query",
+        response_model=QueryEndpointResponse,
+        responses=_REJECTION_RESPONSES,
+    )
     async def query_endpoint(
         slug: str,
         request: QueryEndpointRequest,
@@ -134,16 +158,13 @@ def build_endpoint_routes(
                 slug, auth_request, tenant, x_payment=x_payment
             )
         except QueryRejectedError as e:
-            return JSONResponse(
-                status_code=e.status_code,
-                content={
-                    "detail": e.detail,
-                    "policy_metadata": e.policy_metadata.model_dump(),
-                },
-                headers=e.headers,
-            )
+            return _render_rejection(e)
 
-    @router.post("/{slug}/preview", response_model=QueryEndpointResponse)
+    @router.post(
+        "/{slug}/preview",
+        response_model=QueryEndpointResponse,
+        responses=_REJECTION_RESPONSES,
+    )
     async def preview_endpoint(
         slug: str,
         request: QueryEndpointRequest,
@@ -166,14 +187,7 @@ def build_endpoint_routes(
                 slug, auth_request, tenant, x_payment=None
             )
         except QueryRejectedError as e:
-            return JSONResponse(
-                status_code=e.status_code,
-                content={
-                    "detail": e.detail,
-                    "policy_metadata": e.policy_metadata.model_dump(),
-                },
-                headers=e.headers,
-            )
+            return _render_rejection(e)
 
     # ── Publish routes (PublishEndpointHandler) ──────────────────
 

--- a/backend/syft_space/components/endpoints/schemas.py
+++ b/backend/syft_space/components/endpoints/schemas.py
@@ -11,10 +11,37 @@ from syft_space.components.dataset_types.redaction import (
     redact_config as redact_dataset_config,
 )
 from syft_space.components.endpoints.entities import ResponseType
+from syft_space.components.endpoints.interfaces import QueryOutcome
 from syft_space.components.model_types.redaction import (
     redact_config as redact_model_config,
 )
-from syft_space.components.policy_types.interfaces import PolicyMetadata
+from syft_space.components.policy_types.interfaces import PolicyMetadataEntry
+
+
+class PolicyMetadata(BaseModel):
+    """Aggregate of every policy's entry for one query, plus the overall outcome.
+
+    Assembled by the endpoints layer (success path and rejection path alike),
+    so `outcome` is the endpoints-owned `QueryOutcome` — the full query
+    lifecycle, a superset of the policy-produced `PolicyRejection` categories.
+    """
+
+    outcome: QueryOutcome = Field(..., description="Overall query outcome")
+    entries: list[PolicyMetadataEntry] = Field(default_factory=list)
+
+
+class RejectionResponse(BaseModel):
+    """Body returned when a policy blocks a query (HTTP 402/403).
+
+    Carries the same `policy_metadata` envelope as a successful
+    QueryEndpointResponse, so the SDK reads policy outcomes from one typed
+    field regardless of status code.
+    """
+
+    detail: str = Field(..., description="Human-readable rejection message")
+    policy_metadata: PolicyMetadata = Field(
+        ..., description="Per-policy metadata, including the rejection reason"
+    )
 
 
 class CreateEndpointRequest(BaseModel):

--- a/backend/syft_space/components/endpoints/schemas.py
+++ b/backend/syft_space/components/endpoints/schemas.py
@@ -14,6 +14,7 @@ from syft_space.components.endpoints.entities import ResponseType
 from syft_space.components.model_types.redaction import (
     redact_config as redact_model_config,
 )
+from syft_space.components.policy_types.interfaces import PolicyMetadata
 
 
 class CreateEndpointRequest(BaseModel):
@@ -434,6 +435,11 @@ class QueryEndpointResponse(BaseModel):
     )
     currency: str | None = Field(
         default=None, description="Currency of the cost (ISO code)"
+    )
+    policy_metadata: PolicyMetadata | None = Field(
+        default=None,
+        description="Per-policy metadata: what each policy charged, to whom, "
+        "transaction ids, and rejection reasons",
     )
 
     @model_validator(mode="after")

--- a/backend/syft_space/components/policy_types/access/access_type.py
+++ b/backend/syft_space/components/policy_types/access/access_type.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel, Field
 from syft_space.components.policy_types.interfaces import (
     BasePolicyType,
     PolicyContext,
+    PolicyMetadataEntry,
     PolicyViolationError,
 )
 from syft_space.components.shared.utils import (
@@ -118,10 +119,19 @@ class EndpointAccessPolicy(BasePolicyType):
             denial_reasons.append(reason)
 
         # All policies denied - abort
+        message = f"Access denied: {'; '.join(denial_reasons)}"
         raise PolicyViolationError(
-            message=f"Access denied: {'; '.join(denial_reasons)}",
+            message=message,
             policy_type=self.NAME,
             details={"user": user_email, "reasons": denial_reasons},
+            outcome="access_denied",
+            metadata_entry=PolicyMetadataEntry(
+                policy_type=self.NAME,
+                kind="access",
+                status="rejected",
+                reason_code="ACCESS_DENIED",
+                reason=message,
+            ),
         )
 
     async def post_hook(

--- a/backend/syft_space/components/policy_types/access/access_type.py
+++ b/backend/syft_space/components/policy_types/access/access_type.py
@@ -8,7 +8,9 @@ from syft_space.components.policy_types.interfaces import (
     BasePolicyType,
     PolicyContext,
     PolicyMetadataEntry,
+    PolicyRejection,
     PolicyViolationError,
+    ReasonCode,
 )
 from syft_space.components.shared.utils import (
     ConfigSchemaGenerator,
@@ -124,12 +126,12 @@ class EndpointAccessPolicy(BasePolicyType):
             message=message,
             policy_type=self.NAME,
             details={"user": user_email, "reasons": denial_reasons},
-            outcome="access_denied",
+            outcome=PolicyRejection.ACCESS_DENIED,
             metadata_entry=PolicyMetadataEntry(
                 policy_type=self.NAME,
                 kind="access",
                 status="rejected",
-                reason_code="ACCESS_DENIED",
+                reason_code=ReasonCode.ACCESS_DENIED,
                 reason=message,
             ),
         )

--- a/backend/syft_space/components/policy_types/interfaces.py
+++ b/backend/syft_space/components/policy_types/interfaces.py
@@ -1,10 +1,91 @@
 """Policy type interfaces and domain models."""
 
-from typing import Any, Protocol
+from typing import Any, Literal, Protocol
 from uuid import UUID
 
 from mpp import Challenge, Credential, Receipt
 from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+# --------------------------------------------------------------------------- #
+# Policy metadata contract                                                     #
+#                                                                              #
+# Every query response (success and rejection) carries a PolicyMetadata        #
+# object describing what each policy did: what it charged, to whom, the        #
+# rail-native transaction id, and — for rejections — why it was blocked.       #
+# This is the authoritative source the SDK surfaces (OME-284/285); clients     #
+# no longer reconstruct price/recipient from policy configs.                   #
+# --------------------------------------------------------------------------- #
+
+
+class TransactionRef(BaseModel):
+    """A rail-native payment reference.
+
+    `id` is the underlying rail's own identifier — a Tempo transaction hash
+    for MPP, or the prepaid ledger `transaction_id` (a UUID) for
+    Xendit/Stripe — disambiguated by `rail`.
+    """
+
+    rail: Literal["mpp", "xendit", "stripe"] = Field(
+        ..., description="Settlement rail that produced this transaction"
+    )
+    id: str = Field(
+        ..., description="Rail-native transaction id (tx hash / ledger UUID)"
+    )
+    reference: str | None = Field(
+        default=None, description="Secondary reference (e.g. MPP external_id)"
+    )
+
+
+class Recipient(BaseModel):
+    """Who gets paid for a query — the endpoint owner / publisher."""
+
+    username: str | None = Field(default=None, description="Endpoint owner username")
+    email: str | None = Field(default=None, description="Endpoint owner email")
+    wallet_address: str | None = Field(
+        default=None, description="Public MPP wallet address (never a private key)"
+    )
+
+
+class PolicyMetadataEntry(BaseModel):
+    """One policy's contribution to the query's metadata."""
+
+    policy_type: str = Field(
+        ..., description="Policy type name, e.g. 'mpp_per_request'"
+    )
+    kind: Literal["payment", "access", "transform", "rate_limit"] = Field(
+        ..., description="Category of policy that produced this entry"
+    )
+    status: Literal["charged", "refunded", "free", "rejected", "applied", "skipped"] = (
+        Field(..., description="What happened for this policy on this query")
+    )
+    amount: float | None = Field(default=None, description="Amount charged/refunded")
+    currency: str | None = Field(default=None, description="Currency of the amount")
+    recipient: Recipient | None = Field(
+        default=None, description="Who was/would be paid (payment policies)"
+    )
+    transaction: TransactionRef | None = Field(
+        default=None, description="Settled transaction reference (payment policies)"
+    )
+    reason_code: str | None = Field(
+        default=None,
+        description="Machine code when rejected: PAYMENT_REQUIRED, "
+        "INSUFFICIENT_BALANCE, NO_PRICING_TIER, ACCESS_DENIED, RATE_LIMITED",
+    )
+    reason: str | None = Field(default=None, description="Human-readable explanation")
+    details: dict[str, Any] = Field(
+        default_factory=dict, description="Extra context, e.g. {'documents': 3}"
+    )
+
+
+class PolicyMetadata(BaseModel):
+    """Aggregate of all policy entries for one query.
+
+    `outcome` mirrors the `QueryOutcome` string values. It is kept as a plain
+    string here to avoid an import cycle with the endpoints component.
+    """
+
+    outcome: str = Field(..., description="Overall query outcome (QueryOutcome value)")
+    entries: list[PolicyMetadataEntry] = Field(default_factory=list)
 
 
 class PolicyViolationError(Exception):
@@ -15,7 +96,13 @@ class PolicyViolationError(Exception):
     """
 
     def __init__(
-        self, message: str, policy_type: str, details: dict[str, Any] | None = None
+        self,
+        message: str,
+        policy_type: str,
+        details: dict[str, Any] | None = None,
+        *,
+        outcome: str = "policy_violation",
+        metadata_entry: "PolicyMetadataEntry | None" = None,
     ) -> None:
         """Initialize the PolicyViolationError.
 
@@ -23,10 +110,15 @@ class PolicyViolationError(Exception):
             message: Human-readable error message
             policy_type: Name of the policy type that raised the error
             details: Optional additional details about the error
+            outcome: QueryOutcome value to report (e.g. "policy_violation",
+                "access_denied", "rate_limited")
+            metadata_entry: The rejected PolicyMetadataEntry to surface to the client
         """
         super().__init__(message)
         self.policy_type = policy_type
         self.details = details or {}
+        self.outcome = outcome
+        self.metadata_entry = metadata_entry
 
 
 class PaymentRequiredError(Exception):
@@ -36,10 +128,41 @@ class PaymentRequiredError(Exception):
     The endpoint handler should catch this and return HTTP 402.
     """
 
-    def __init__(self, www_authenticate: str, description: str | None = None):
+    def __init__(
+        self,
+        www_authenticate: str,
+        description: str | None = None,
+        *,
+        metadata_entry: "PolicyMetadataEntry | None" = None,
+    ):
         self.www_authenticate = www_authenticate
         self.description = description
+        self.metadata_entry = metadata_entry
         super().__init__(description or "Payment required")
+
+
+class QueryRejectedError(Exception):
+    """A query was rejected by a policy (payment/access/rate-limit).
+
+    Carries everything the route needs to render the rejection body with the
+    same `policy_metadata` envelope as a successful response. Built by the
+    query handler from PaymentRequiredError / PolicyViolationError so the
+    route has a single rejection branch.
+    """
+
+    def __init__(
+        self,
+        *,
+        status_code: int,
+        detail: str,
+        policy_metadata: "PolicyMetadata",
+        headers: dict[str, str] | None = None,
+    ) -> None:
+        self.status_code = status_code
+        self.detail = detail
+        self.policy_metadata = policy_metadata
+        self.headers = headers
+        super().__init__(detail)
 
 
 class PolicyAttachError(Exception):
@@ -257,12 +380,25 @@ class PolicyContext(BaseModel):
         default=None, description="Response payload (for post hooks)"
     )
     metadata: dict[str, Any] = Field(
-        default_factory=dict, description="Additional metadata"
+        default_factory=dict,
+        description="Cross-hook scratch (transaction id handoff, etc.)",
     )
     payment_chargers: PaymentChargers | None = Field(
         default=None,
         description="Per-request payment chargers, built from attached wallets",
     )
+    recipient: Recipient | None = Field(
+        default=None,
+        description="Endpoint owner identity (the 'to whom' for payment entries)",
+    )
+    policy_metadata: list[PolicyMetadataEntry] = Field(
+        default_factory=list,
+        description="Accumulated per-policy metadata entries for this query",
+    )
+
+    def add_policy_metadata(self, entry: PolicyMetadataEntry) -> None:
+        """Append a policy's metadata entry, surfaced on the query response."""
+        self.policy_metadata.append(entry)
 
 
 class BasePolicyType(Protocol):

--- a/backend/syft_space/components/policy_types/interfaces.py
+++ b/backend/syft_space/components/policy_types/interfaces.py
@@ -1,5 +1,6 @@
 """Policy type interfaces and domain models."""
 
+from enum import Enum
 from typing import Any, Literal, Protocol
 from uuid import UUID
 
@@ -9,12 +10,41 @@ from pydantic import BaseModel, ConfigDict, EmailStr, Field
 # --------------------------------------------------------------------------- #
 # Policy metadata contract                                                     #
 #                                                                              #
-# Every query response (success and rejection) carries a PolicyMetadata        #
-# object describing what each policy did: what it charged, to whom, the        #
-# rail-native transaction id, and — for rejections — why it was blocked.       #
-# This is the authoritative source the SDK surfaces (OME-284/285); clients     #
-# no longer reconstruct price/recipient from policy configs.                   #
+# Each policy contributes a PolicyMetadataEntry describing what it did: what   #
+# it charged, to whom, the rail-native transaction id, and — for rejections —  #
+# why it blocked the query. The endpoints layer aggregates these into the      #
+# PolicyMetadata envelope returned on the query response (endpoints.schemas).  #
+# It is the authoritative source of price/recipient/outcome for API clients.   #
 # --------------------------------------------------------------------------- #
+
+
+class PolicyRejection(str, Enum):
+    """The categories of rejection a policy can produce.
+
+    Owned by `policy_types` because policies are what *produce* these — unlike
+    the endpoints-owned `QueryOutcome`, which also covers query-lifecycle
+    states no policy emits (success, not_found, not_published, internal_error).
+    `QueryOutcome` is a deliberate value-superset; the endpoints layer coerces
+    a PolicyRejection into its QueryOutcome twin at the rejection boundary.
+    """
+
+    POLICY_VIOLATION = "policy_violation"
+    ACCESS_DENIED = "access_denied"
+    RATE_LIMITED = "rate_limited"
+
+
+class ReasonCode(str, Enum):
+    """Machine-readable code on a rejected PolicyMetadataEntry.
+
+    A stable contract the SDK can switch on, distinct from the human-readable
+    `reason`. Owned by `policy_types` because policies are what produce them.
+    """
+
+    NO_PRICING_TIER = "NO_PRICING_TIER"
+    INSUFFICIENT_BALANCE = "INSUFFICIENT_BALANCE"
+    PAYMENT_REQUIRED = "PAYMENT_REQUIRED"
+    ACCESS_DENIED = "ACCESS_DENIED"
+    RATE_LIMITED = "RATE_LIMITED"
 
 
 class TransactionRef(BaseModel):
@@ -66,26 +96,13 @@ class PolicyMetadataEntry(BaseModel):
     transaction: TransactionRef | None = Field(
         default=None, description="Settled transaction reference (payment policies)"
     )
-    reason_code: str | None = Field(
-        default=None,
-        description="Machine code when rejected: PAYMENT_REQUIRED, "
-        "INSUFFICIENT_BALANCE, NO_PRICING_TIER, ACCESS_DENIED, RATE_LIMITED",
+    reason_code: ReasonCode | None = Field(
+        default=None, description="Machine-readable rejection code (see ReasonCode)"
     )
     reason: str | None = Field(default=None, description="Human-readable explanation")
     details: dict[str, Any] = Field(
         default_factory=dict, description="Extra context, e.g. {'documents': 3}"
     )
-
-
-class PolicyMetadata(BaseModel):
-    """Aggregate of all policy entries for one query.
-
-    `outcome` mirrors the `QueryOutcome` string values. It is kept as a plain
-    string here to avoid an import cycle with the endpoints component.
-    """
-
-    outcome: str = Field(..., description="Overall query outcome (QueryOutcome value)")
-    entries: list[PolicyMetadataEntry] = Field(default_factory=list)
 
 
 class PolicyViolationError(Exception):
@@ -101,7 +118,7 @@ class PolicyViolationError(Exception):
         policy_type: str,
         details: dict[str, Any] | None = None,
         *,
-        outcome: str = "policy_violation",
+        outcome: PolicyRejection = PolicyRejection.POLICY_VIOLATION,
         metadata_entry: "PolicyMetadataEntry | None" = None,
     ) -> None:
         """Initialize the PolicyViolationError.
@@ -110,14 +127,13 @@ class PolicyViolationError(Exception):
             message: Human-readable error message
             policy_type: Name of the policy type that raised the error
             details: Optional additional details about the error
-            outcome: QueryOutcome value to report (e.g. "policy_violation",
-                "access_denied", "rate_limited")
+            outcome: The rejection category (defaults to POLICY_VIOLATION)
             metadata_entry: The rejected PolicyMetadataEntry to surface to the client
         """
         super().__init__(message)
         self.policy_type = policy_type
         self.details = details or {}
-        self.outcome = outcome
+        self.outcome: PolicyRejection = outcome
         self.metadata_entry = metadata_entry
 
 
@@ -139,30 +155,6 @@ class PaymentRequiredError(Exception):
         self.description = description
         self.metadata_entry = metadata_entry
         super().__init__(description or "Payment required")
-
-
-class QueryRejectedError(Exception):
-    """A query was rejected by a policy (payment/access/rate-limit).
-
-    Carries everything the route needs to render the rejection body with the
-    same `policy_metadata` envelope as a successful response. Built by the
-    query handler from PaymentRequiredError / PolicyViolationError so the
-    route has a single rejection branch.
-    """
-
-    def __init__(
-        self,
-        *,
-        status_code: int,
-        detail: str,
-        policy_metadata: "PolicyMetadata",
-        headers: dict[str, str] | None = None,
-    ) -> None:
-        self.status_code = status_code
-        self.detail = detail
-        self.policy_metadata = policy_metadata
-        self.headers = headers
-        super().__init__(detail)
 
 
 class PolicyAttachError(Exception):

--- a/backend/syft_space/components/policy_types/mpp/mpp_payment_policy.py
+++ b/backend/syft_space/components/policy_types/mpp/mpp_payment_policy.py
@@ -43,10 +43,11 @@ from syft_space.components.policy_types.interfaces import (
     TransactionRef,
 )
 from syft_space.components.policy_types.mpp.policy_config import MppPaymentConfig
+from syft_space.components.policy_types.payment_metadata import PaymentMetadataMixin
 from syft_space.components.shared.utils import matches_any_pattern
 
 
-class MppPaymentPolicy(BasePolicyType):
+class MppPaymentPolicy(PaymentMetadataMixin, BasePolicyType):
     """Shared scaffolding for all MPP-based payment policies."""
 
     NAME: ClassVar[str]
@@ -113,12 +114,10 @@ class MppPaymentPolicy(BasePolicyType):
 
         return best_price
 
-    # ----------------------------------------------------------------- #
-    # PolicyMetadataEntry builders — keep emitted entries DRY across the #
-    # per-request / per-document subclasses. Each fills in the invariant #
-    # policy_type / kind / recipient and lets callers supply only the    #
-    # varying fields.                                                    #
-    # ----------------------------------------------------------------- #
+    # PolicyMetadataEntry builders. The invariant shape (policy_type / kind /
+    # recipient / status) lives in PaymentMetadataMixin; only the MPP-rail
+    # TransactionRef is built here. `_free_entry` / `_rejected_entry` are
+    # inherited from the mixin.
     def _charged_entry(
         self,
         context: PolicyContext,
@@ -144,54 +143,11 @@ class MppPaymentPolicy(BasePolicyType):
                 id=reference,
                 reference=external_id,
             )
-        return PolicyMetadataEntry(
-            policy_type=self.NAME,
-            kind="payment",
+        return self._payment_entry(
+            context,
             status="charged",
             amount=amount,
             currency=currency,
-            recipient=context.recipient,
             transaction=transaction,
-            details=details or {},
-        )
-
-    def _free_entry(
-        self,
-        context: PolicyContext,
-        *,
-        currency: str = "USD",
-        details: dict[str, Any] | None = None,
-    ) -> PolicyMetadataEntry:
-        """Build a 'free' (amount=0) entry."""
-        return PolicyMetadataEntry(
-            policy_type=self.NAME,
-            kind="payment",
-            status="free",
-            amount=0,
-            currency=currency,
-            recipient=context.recipient,
-            details=details or {},
-        )
-
-    def _rejected_entry(
-        self,
-        context: PolicyContext,
-        *,
-        reason_code: str,
-        reason: str,
-        amount: float | None = None,
-        currency: str | None = None,
-        details: dict[str, Any] | None = None,
-    ) -> PolicyMetadataEntry:
-        """Build a 'rejected' entry (payment required / no tier)."""
-        return PolicyMetadataEntry(
-            policy_type=self.NAME,
-            kind="payment",
-            status="rejected",
-            amount=amount,
-            currency=currency,
-            recipient=context.recipient,
-            reason_code=reason_code,
-            reason=reason,
-            details=details or {},
+            details=details,
         )

--- a/backend/syft_space/components/policy_types/mpp/mpp_payment_policy.py
+++ b/backend/syft_space/components/policy_types/mpp/mpp_payment_policy.py
@@ -38,6 +38,9 @@ from typing import Any, ClassVar
 from syft_space.components.policy_types.interfaces import (
     BasePolicyType,
     Capabilities,
+    PolicyContext,
+    PolicyMetadataEntry,
+    TransactionRef,
 )
 from syft_space.components.policy_types.mpp.policy_config import MppPaymentConfig
 from syft_space.components.shared.utils import matches_any_pattern
@@ -109,3 +112,86 @@ class MppPaymentPolicy(BasePolicyType):
                     best_price = validated.price
 
         return best_price
+
+    # ----------------------------------------------------------------- #
+    # PolicyMetadataEntry builders — keep emitted entries DRY across the #
+    # per-request / per-document subclasses. Each fills in the invariant #
+    # policy_type / kind / recipient and lets callers supply only the    #
+    # varying fields.                                                    #
+    # ----------------------------------------------------------------- #
+    def _charged_entry(
+        self,
+        context: PolicyContext,
+        *,
+        amount: float,
+        currency: str = "USD",
+        reference: str | None,
+        external_id: str | None,
+        details: dict[str, Any] | None = None,
+    ) -> PolicyMetadataEntry:
+        """Build a 'charged' entry.
+
+        ``TransactionRef.id`` is a required str. MPP receipts can lack a
+        ``reference`` (e.g. settlement metadata missing), which would make
+        pydantic raise *after* the charge already settled. Guard here: only
+        attach a ``transaction`` when a reference is present; otherwise emit
+        the entry with ``transaction=None`` (status/amount/recipient intact).
+        """
+        transaction: TransactionRef | None = None
+        if reference is not None:
+            transaction = TransactionRef(
+                rail="mpp",
+                id=reference,
+                reference=external_id,
+            )
+        return PolicyMetadataEntry(
+            policy_type=self.NAME,
+            kind="payment",
+            status="charged",
+            amount=amount,
+            currency=currency,
+            recipient=context.recipient,
+            transaction=transaction,
+            details=details or {},
+        )
+
+    def _free_entry(
+        self,
+        context: PolicyContext,
+        *,
+        currency: str = "USD",
+        details: dict[str, Any] | None = None,
+    ) -> PolicyMetadataEntry:
+        """Build a 'free' (amount=0) entry."""
+        return PolicyMetadataEntry(
+            policy_type=self.NAME,
+            kind="payment",
+            status="free",
+            amount=0,
+            currency=currency,
+            recipient=context.recipient,
+            details=details or {},
+        )
+
+    def _rejected_entry(
+        self,
+        context: PolicyContext,
+        *,
+        reason_code: str,
+        reason: str,
+        amount: float | None = None,
+        currency: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> PolicyMetadataEntry:
+        """Build a 'rejected' entry (payment required / no tier)."""
+        return PolicyMetadataEntry(
+            policy_type=self.NAME,
+            kind="payment",
+            status="rejected",
+            amount=amount,
+            currency=currency,
+            recipient=context.recipient,
+            reason_code=reason_code,
+            reason=reason,
+            details=details or {},
+        )

--- a/backend/syft_space/components/policy_types/mpp/mpp_per_document.py
+++ b/backend/syft_space/components/policy_types/mpp/mpp_per_document.py
@@ -16,6 +16,7 @@ from syft_space.components.policy_types.interfaces import (
     PaymentRequiredError,
     PolicyContext,
     PolicyViolationError,
+    ReasonCode,
     add_response_cost,
 )
 from syft_space.components.policy_types.mpp.mpp_payment_policy import (
@@ -120,7 +121,7 @@ class MppPerDocumentPolicy(MppPaymentPolicy):
                 description=description,
                 metadata_entry=self._rejected_entry(
                     context,
-                    reason_code="PAYMENT_REQUIRED",
+                    reason_code=ReasonCode.PAYMENT_REQUIRED,
                     reason=description,
                     amount=total,
                     currency="USD",

--- a/backend/syft_space/components/policy_types/mpp/mpp_per_document.py
+++ b/backend/syft_space/components/policy_types/mpp/mpp_per_document.py
@@ -100,6 +100,9 @@ class MppPerDocumentPolicy(MppPaymentPolicy):
         # before doing the (no-op) charge.
         if price == 0 or count == 0:
             add_response_cost(response, 0, "USD")
+            context.add_policy_metadata(
+                self._free_entry(context, details={"documents": count})
+            )
             return context
 
         total = count * price
@@ -111,9 +114,18 @@ class MppPerDocumentPolicy(MppPaymentPolicy):
 
         if isinstance(result, Challenge):
             www_authenticate = result.to_www_authenticate(realm=context.endpoint_slug)
+            description = f"Payment of ${total} required for {count} documents"
             raise PaymentRequiredError(
                 www_authenticate=www_authenticate,
-                description=(f"Payment of ${total} required for {count} documents"),
+                description=description,
+                metadata_entry=self._rejected_entry(
+                    context,
+                    reason_code="PAYMENT_REQUIRED",
+                    reason=description,
+                    amount=total,
+                    currency="USD",
+                    details={"documents": count},
+                ),
             )
 
         credential, receipt = result
@@ -123,9 +135,18 @@ class MppPerDocumentPolicy(MppPaymentPolicy):
             "status": receipt.status,
             "external_id": receipt.external_id,
         }
-        context.metadata["payment_receipt_header"] = receipt.reference
 
         add_response_cost(context.response, total, "USD")
+
+        context.add_policy_metadata(
+            self._charged_entry(
+                context,
+                amount=total,
+                reference=receipt.reference,
+                external_id=receipt.external_id,
+                details={"documents": count},
+            )
+        )
 
         logger.info(
             f"MPP per-document payment verified: ${total} from "

--- a/backend/syft_space/components/policy_types/mpp/mpp_per_request.py
+++ b/backend/syft_space/components/policy_types/mpp/mpp_per_request.py
@@ -66,9 +66,17 @@ class MppPerRequestPolicy(MppPaymentPolicy):
 
         if isinstance(result, Challenge):
             www_authenticate = result.to_www_authenticate(realm=context.endpoint_slug)
+            description = f"Payment of ${price} required to query this endpoint"
             raise PaymentRequiredError(
                 www_authenticate=www_authenticate,
-                description=f"Payment of ${price} required to query this endpoint",
+                description=description,
+                metadata_entry=self._rejected_entry(
+                    context,
+                    reason_code="PAYMENT_REQUIRED",
+                    reason=description,
+                    amount=price,
+                    currency="USD",
+                ),
             )
 
         credential, receipt = result
@@ -92,7 +100,7 @@ class MppPerRequestPolicy(MppPaymentPolicy):
         self, configs: list[dict[str, Any]], context: PolicyContext
     ) -> PolicyContext:
         """Post-hook: add this policy's charge to the response total and
-        stash the receipt reference for the Payment-Receipt header.
+        emit its policy-metadata entry.
 
         The price from the matched tier is always added (including 0 for
         free tiers) so the response always reflects what *this policy*
@@ -103,11 +111,23 @@ class MppPerRequestPolicy(MppPaymentPolicy):
             return context
 
         price = self._find_matching_price(context.sender_email, configs)
-        if price is not None:
-            add_response_cost(context.response, price, "USD")
+        if price is None:
+            return context
 
-        receipt_info = context.metadata.get("mpp_receipt")
-        if receipt_info:
-            context.metadata["payment_receipt_header"] = receipt_info.get("reference")
+        add_response_cost(context.response, price, "USD")
+
+        if price == 0:
+            context.add_policy_metadata(self._free_entry(context))
+            return context
+
+        receipt_info = context.metadata.get("mpp_receipt") or {}
+        context.add_policy_metadata(
+            self._charged_entry(
+                context,
+                amount=price,
+                reference=receipt_info.get("reference"),
+                external_id=receipt_info.get("external_id"),
+            )
+        )
 
         return context

--- a/backend/syft_space/components/policy_types/mpp/mpp_per_request.py
+++ b/backend/syft_space/components/policy_types/mpp/mpp_per_request.py
@@ -10,6 +10,7 @@ from syft_space.components.policy_types.interfaces import (
     PaymentRequiredError,
     PolicyContext,
     PolicyViolationError,
+    ReasonCode,
     add_response_cost,
 )
 from syft_space.components.policy_types.mpp.mpp_payment_policy import (
@@ -72,7 +73,7 @@ class MppPerRequestPolicy(MppPaymentPolicy):
                 description=description,
                 metadata_entry=self._rejected_entry(
                     context,
-                    reason_code="PAYMENT_REQUIRED",
+                    reason_code=ReasonCode.PAYMENT_REQUIRED,
                     reason=description,
                     amount=price,
                     currency="USD",

--- a/backend/syft_space/components/policy_types/payment_metadata.py
+++ b/backend/syft_space/components/policy_types/payment_metadata.py
@@ -1,0 +1,83 @@
+"""Shared PolicyMetadataEntry construction for payment policies.
+
+Every payment policy — prepaid-balance (Stripe/Xendit) and MPP alike — emits
+entries with the same invariant shape: ``policy_type`` / ``kind="payment"`` /
+``recipient``, varying only in status and the rail-specific ``TransactionRef``.
+This mixin owns that invariant so an entry's shape is defined exactly once; each
+family supplies only its rail's transaction via ``_charged_entry`` /
+``_refunded_entry``.
+"""
+
+from typing import Any, ClassVar
+
+from syft_space.components.policy_types.interfaces import (
+    PolicyContext,
+    PolicyMetadataEntry,
+    ReasonCode,
+    TransactionRef,
+)
+
+
+class PaymentMetadataMixin:
+    """Builds the invariant parts of a payment policy's PolicyMetadataEntry."""
+
+    NAME: ClassVar[str]
+
+    def _payment_entry(
+        self,
+        context: PolicyContext,
+        *,
+        status: str,
+        amount: float | None = None,
+        currency: str | None = None,
+        transaction: TransactionRef | None = None,
+        reason_code: ReasonCode | None = None,
+        reason: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> PolicyMetadataEntry:
+        """Assemble a payment entry, filling the fields invariant across rails."""
+        return PolicyMetadataEntry(
+            policy_type=self.NAME,
+            kind="payment",
+            status=status,
+            amount=amount,
+            currency=currency,
+            recipient=context.recipient,
+            transaction=transaction,
+            reason_code=reason_code,
+            reason=reason,
+            details=details or {},
+        )
+
+    def _free_entry(
+        self,
+        context: PolicyContext,
+        *,
+        currency: str = "USD",
+        details: dict[str, Any] | None = None,
+    ) -> PolicyMetadataEntry:
+        """Build a 'free' (amount=0) entry — no charge made."""
+        return self._payment_entry(
+            context, status="free", amount=0, currency=currency, details=details
+        )
+
+    def _rejected_entry(
+        self,
+        context: PolicyContext,
+        *,
+        reason_code: ReasonCode,
+        reason: str,
+        amount: float | None = None,
+        currency: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> PolicyMetadataEntry:
+        """Build a 'rejected' entry (no tier / insufficient balance / etc.)."""
+        return self._payment_entry(
+            context,
+            status="rejected",
+            amount=amount,
+            currency=currency,
+            reason_code=reason_code,
+            reason=reason,
+            details=details,
+        )

--- a/backend/syft_space/components/policy_types/pii_filter/pii_filter_type.py
+++ b/backend/syft_space/components/policy_types/pii_filter/pii_filter_type.py
@@ -24,14 +24,20 @@ from syft_space.components.model_types.interfaces import (
 from syft_space.components.policy_types.interfaces import (
     BasePolicyType,
     PolicyContext,
+    PolicyMetadataEntry,
 )
 from syft_space.components.shared.utils import ConfigSchemaGenerator
 
-_PII_SYSTEM_PROMPT = """\
-You are a PII (Personally Identifiable Information) sanitization assistant.
-Review the provided text and replace any PII with the placeholder [REDACTED].
+# The placeholder the model is told to substitute for PII. The
+# `spans_redacted` count below greps for this exact token, so the prompt and
+# the count stay coupled through this single constant.
+_REDACTION_TOKEN = "[REDACTED]"
 
-Replace the following with [REDACTED]:
+_PII_SYSTEM_PROMPT = f"""\
+You are a PII (Personally Identifiable Information) sanitization assistant.
+Review the provided text and replace any PII with the placeholder {_REDACTION_TOKEN}.
+
+Replace the following with {_REDACTION_TOKEN}:
 - Full names of real individuals
 - Email addresses
 - Phone numbers
@@ -96,7 +102,9 @@ class PiiFilterType(BasePolicyType):
         return PiiFilterConfig.model_json_schema(schema_generator=ConfigSchemaGenerator)
 
     async def pre_hook(
-        self, configs: list[dict[str, Any]], context: PolicyContext  # noqa: ARG002
+        self,
+        configs: list[dict[str, Any]],
+        context: PolicyContext,  # noqa: ARG002
     ) -> PolicyContext:
         """No pre-request work — PII sanitization only runs on responses."""
         return context
@@ -153,6 +161,15 @@ class PiiFilterType(BasePolicyType):
             if result.messages:
                 sanitized = result.messages[-1].content.strip()
                 context.response = self._replace_text(context.response, sanitized)
+                spans_redacted = sanitized.count(_REDACTION_TOKEN)
+                context.add_policy_metadata(
+                    PolicyMetadataEntry(
+                        policy_type=self.NAME,
+                        kind="transform",
+                        status="applied",
+                        details={"spans_redacted": spans_redacted},
+                    )
+                )
         except Exception as exc:
             logger.warning(
                 f"PII filter: model sanitization call failed, skipping redaction: {exc}"

--- a/backend/syft_space/components/policy_types/prepaid/payment_policy.py
+++ b/backend/syft_space/components/policy_types/prepaid/payment_policy.py
@@ -6,11 +6,15 @@ export, tier matching, identity boilerplate — is provider-agnostic and
 lives here.
 """
 
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal, cast
+from uuid import UUID
 
 from syft_space.components.policy_types.interfaces import (
     BasePolicyType,
     Capabilities,
+    PolicyContext,
+    PolicyMetadataEntry,
+    TransactionRef,
 )
 from syft_space.components.shared.utils import (
     ConfigSchemaGenerator,
@@ -93,3 +97,110 @@ class PrepaidBalancePaymentPolicyBase(BasePolicyType):
                     best_price = validated.price
 
         return best_price
+
+    # ----------------------------------------------------------------- #
+    # PolicyMetadataEntry builders — keep emitted entries DRY across the #
+    # per-request / per-document subclasses. Each fills in the invariant #
+    # policy_type / kind / recipient and lets callers supply only the    #
+    # varying fields.                                                    #
+    # ----------------------------------------------------------------- #
+    @staticmethod
+    def _prepaid_transaction(
+        wallet_type: str, transaction_id: UUID | str | None
+    ) -> TransactionRef | None:
+        """Build a TransactionRef, guarding a None ledger id.
+
+        ``TransactionRef.id`` is a required str; defensively skip attaching a
+        transaction when the ledger id is missing rather than letting pydantic
+        raise after the balance was already reserved.
+        """
+        if transaction_id is None:
+            return None
+        return TransactionRef(
+            rail=cast(Literal["xendit", "stripe"], wallet_type),
+            id=str(transaction_id),
+        )
+
+    def _charged_entry(
+        self,
+        context: PolicyContext,
+        *,
+        amount: float,
+        currency: str,
+        wallet_type: str,
+        transaction_id: UUID | str | None,
+        details: dict[str, Any] | None = None,
+    ) -> PolicyMetadataEntry:
+        """Build a 'charged' entry."""
+        return PolicyMetadataEntry(
+            policy_type=self.NAME,
+            kind="payment",
+            status="charged",
+            amount=amount,
+            currency=currency,
+            recipient=context.recipient,
+            transaction=self._prepaid_transaction(wallet_type, transaction_id),
+            details=details or {},
+        )
+
+    def _refunded_entry(
+        self,
+        context: PolicyContext,
+        *,
+        currency: str,
+        wallet_type: str,
+        transaction_id: UUID | str | None,
+        details: dict[str, Any] | None = None,
+    ) -> PolicyMetadataEntry:
+        """Build a 'refunded' (amount=0) entry — reservation cancelled."""
+        return PolicyMetadataEntry(
+            policy_type=self.NAME,
+            kind="payment",
+            status="refunded",
+            amount=0,
+            currency=currency,
+            recipient=context.recipient,
+            transaction=self._prepaid_transaction(wallet_type, transaction_id),
+            details=details or {},
+        )
+
+    def _free_entry(
+        self,
+        context: PolicyContext,
+        *,
+        currency: str,
+        details: dict[str, Any] | None = None,
+    ) -> PolicyMetadataEntry:
+        """Build a 'free' (amount=0) entry — no charge made."""
+        return PolicyMetadataEntry(
+            policy_type=self.NAME,
+            kind="payment",
+            status="free",
+            amount=0,
+            currency=currency,
+            recipient=context.recipient,
+            details=details or {},
+        )
+
+    def _rejected_entry(
+        self,
+        context: PolicyContext,
+        *,
+        reason_code: str,
+        reason: str,
+        amount: float | None = None,
+        currency: str | None = None,
+        details: dict[str, Any] | None = None,
+    ) -> PolicyMetadataEntry:
+        """Build a 'rejected' entry (no tier / insufficient balance)."""
+        return PolicyMetadataEntry(
+            policy_type=self.NAME,
+            kind="payment",
+            status="rejected",
+            amount=amount,
+            currency=currency,
+            recipient=context.recipient,
+            reason_code=reason_code,
+            reason=reason,
+            details=details or {},
+        )

--- a/backend/syft_space/components/policy_types/prepaid/payment_policy.py
+++ b/backend/syft_space/components/policy_types/prepaid/payment_policy.py
@@ -16,13 +16,14 @@ from syft_space.components.policy_types.interfaces import (
     PolicyMetadataEntry,
     TransactionRef,
 )
+from syft_space.components.policy_types.payment_metadata import PaymentMetadataMixin
 from syft_space.components.shared.utils import (
     ConfigSchemaGenerator,
     matches_any_pattern,
 )
 
 
-class PrepaidBalancePaymentPolicyBase(BasePolicyType):
+class PrepaidBalancePaymentPolicyBase(PaymentMetadataMixin, BasePolicyType):
     """Shared scaffolding for all prepaid-balance payment policies."""
 
     PROVIDER_NAME: ClassVar[str]  # "stripe", "xendit", ...
@@ -98,12 +99,10 @@ class PrepaidBalancePaymentPolicyBase(BasePolicyType):
 
         return best_price
 
-    # ----------------------------------------------------------------- #
-    # PolicyMetadataEntry builders — keep emitted entries DRY across the #
-    # per-request / per-document subclasses. Each fills in the invariant #
-    # policy_type / kind / recipient and lets callers supply only the    #
-    # varying fields.                                                    #
-    # ----------------------------------------------------------------- #
+    # PolicyMetadataEntry builders. The invariant shape (policy_type / kind /
+    # recipient / status) lives in PaymentMetadataMixin; only the prepaid-rail
+    # TransactionRef is built here. `_free_entry` / `_rejected_entry` are
+    # inherited from the mixin.
     @staticmethod
     def _prepaid_transaction(
         wallet_type: str, transaction_id: UUID | str | None
@@ -132,15 +131,13 @@ class PrepaidBalancePaymentPolicyBase(BasePolicyType):
         details: dict[str, Any] | None = None,
     ) -> PolicyMetadataEntry:
         """Build a 'charged' entry."""
-        return PolicyMetadataEntry(
-            policy_type=self.NAME,
-            kind="payment",
+        return self._payment_entry(
+            context,
             status="charged",
             amount=amount,
             currency=currency,
-            recipient=context.recipient,
             transaction=self._prepaid_transaction(wallet_type, transaction_id),
-            details=details or {},
+            details=details,
         )
 
     def _refunded_entry(
@@ -153,54 +150,11 @@ class PrepaidBalancePaymentPolicyBase(BasePolicyType):
         details: dict[str, Any] | None = None,
     ) -> PolicyMetadataEntry:
         """Build a 'refunded' (amount=0) entry — reservation cancelled."""
-        return PolicyMetadataEntry(
-            policy_type=self.NAME,
-            kind="payment",
+        return self._payment_entry(
+            context,
             status="refunded",
             amount=0,
             currency=currency,
-            recipient=context.recipient,
             transaction=self._prepaid_transaction(wallet_type, transaction_id),
-            details=details or {},
-        )
-
-    def _free_entry(
-        self,
-        context: PolicyContext,
-        *,
-        currency: str,
-        details: dict[str, Any] | None = None,
-    ) -> PolicyMetadataEntry:
-        """Build a 'free' (amount=0) entry — no charge made."""
-        return PolicyMetadataEntry(
-            policy_type=self.NAME,
-            kind="payment",
-            status="free",
-            amount=0,
-            currency=currency,
-            recipient=context.recipient,
-            details=details or {},
-        )
-
-    def _rejected_entry(
-        self,
-        context: PolicyContext,
-        *,
-        reason_code: str,
-        reason: str,
-        amount: float | None = None,
-        currency: str | None = None,
-        details: dict[str, Any] | None = None,
-    ) -> PolicyMetadataEntry:
-        """Build a 'rejected' entry (no tier / insufficient balance)."""
-        return PolicyMetadataEntry(
-            policy_type=self.NAME,
-            kind="payment",
-            status="rejected",
-            amount=amount,
-            currency=currency,
-            recipient=context.recipient,
-            reason_code=reason_code,
-            reason=reason,
-            details=details or {},
+            details=details,
         )

--- a/backend/syft_space/components/policy_types/prepaid/per_document.py
+++ b/backend/syft_space/components/policy_types/prepaid/per_document.py
@@ -52,16 +52,24 @@ class PrepaidBalancePerDocumentPolicy(PrepaidBalancePaymentPolicyBase):
         price = self._find_matching_price(user_email, configs)
 
         if price is None:
+            message = "No pricing tier matches your account"
             raise PolicyViolationError(
-                message="No pricing tier matches your account",
+                message=message,
                 policy_type=self.NAME,
+                outcome="policy_violation",
+                metadata_entry=self._rejected_entry(
+                    context,
+                    reason_code="NO_PRICING_TIER",
+                    reason=message,
+                ),
             )
 
         charger = context.payment_chargers.prepaid()
         balance = await charger.get_balance(user_email)
         if balance < price:
+            message = "Insufficient balance. Please purchase more credits."
             raise PolicyViolationError(
-                message="Insufficient balance. Please purchase more credits.",
+                message=message,
                 policy_type=self.NAME,
                 details={
                     "user": user_email,
@@ -69,6 +77,15 @@ class PrepaidBalancePerDocumentPolicy(PrepaidBalancePaymentPolicyBase):
                     "price": price,
                     "currency": charger.currency,
                 },
+                outcome="policy_violation",
+                metadata_entry=self._rejected_entry(
+                    context,
+                    reason_code="INSUFFICIENT_BALANCE",
+                    reason=message,
+                    amount=price,
+                    currency=charger.currency,
+                    details={"balance": balance, "price": price},
+                ),
             )
 
         context.metadata["prepaid_per_doc_price"] = price
@@ -101,21 +118,29 @@ class PrepaidBalancePerDocumentPolicy(PrepaidBalancePaymentPolicyBase):
         # this policy applied with no net cost.
         if count == 0:
             add_response_cost(response, 0, charger.currency)
+            context.add_policy_metadata(
+                self._free_entry(
+                    context,
+                    currency=charger.currency,
+                    details={"documents": count},
+                )
+            )
             return context
 
         total = count * price
         user_email = str(context.sender_email)
 
         try:
-            await charger.reserve(
+            transaction_id = await charger.reserve(
                 user_email=user_email,
                 amount=total,
                 charge_unit="document",
                 charge_quantity=count,
             )
         except BalanceShortfallError as exc:
+            message = "Insufficient balance for the documents retrieved."
             raise PolicyViolationError(
-                message="Insufficient balance for the documents retrieved.",
+                message=message,
                 policy_type=self.NAME,
                 details={
                     "user": user_email,
@@ -124,8 +149,27 @@ class PrepaidBalancePerDocumentPolicy(PrepaidBalancePaymentPolicyBase):
                     "total": total,
                     "currency": exc.currency,
                 },
+                outcome="policy_violation",
+                metadata_entry=self._rejected_entry(
+                    context,
+                    reason_code="INSUFFICIENT_BALANCE",
+                    reason=message,
+                    amount=total,
+                    currency=exc.currency,
+                    details={"documents": count, "price": price},
+                ),
             ) from exc
 
         add_response_cost(response, total, charger.currency)
+        context.add_policy_metadata(
+            self._charged_entry(
+                context,
+                amount=total,
+                currency=charger.currency,
+                wallet_type=charger.wallet_type,
+                transaction_id=transaction_id,
+                details={"documents": count},
+            )
+        )
 
         return context

--- a/backend/syft_space/components/policy_types/prepaid/per_document.py
+++ b/backend/syft_space/components/policy_types/prepaid/per_document.py
@@ -15,6 +15,7 @@ from syft_space.components.policy_types.interfaces import (
     Capabilities,
     PolicyContext,
     PolicyViolationError,
+    ReasonCode,
     add_response_cost,
 )
 from syft_space.components.policy_types.prepaid.payment_policy import (
@@ -56,10 +57,9 @@ class PrepaidBalancePerDocumentPolicy(PrepaidBalancePaymentPolicyBase):
             raise PolicyViolationError(
                 message=message,
                 policy_type=self.NAME,
-                outcome="policy_violation",
                 metadata_entry=self._rejected_entry(
                     context,
-                    reason_code="NO_PRICING_TIER",
+                    reason_code=ReasonCode.NO_PRICING_TIER,
                     reason=message,
                 ),
             )
@@ -77,10 +77,9 @@ class PrepaidBalancePerDocumentPolicy(PrepaidBalancePaymentPolicyBase):
                     "price": price,
                     "currency": charger.currency,
                 },
-                outcome="policy_violation",
                 metadata_entry=self._rejected_entry(
                     context,
-                    reason_code="INSUFFICIENT_BALANCE",
+                    reason_code=ReasonCode.INSUFFICIENT_BALANCE,
                     reason=message,
                     amount=price,
                     currency=charger.currency,
@@ -149,10 +148,9 @@ class PrepaidBalancePerDocumentPolicy(PrepaidBalancePaymentPolicyBase):
                     "total": total,
                     "currency": exc.currency,
                 },
-                outcome="policy_violation",
                 metadata_entry=self._rejected_entry(
                     context,
-                    reason_code="INSUFFICIENT_BALANCE",
+                    reason_code=ReasonCode.INSUFFICIENT_BALANCE,
                     reason=message,
                     amount=total,
                     currency=exc.currency,

--- a/backend/syft_space/components/policy_types/prepaid/per_request.py
+++ b/backend/syft_space/components/policy_types/prepaid/per_request.py
@@ -16,6 +16,7 @@ from syft_space.components.policy_types.interfaces import (
     BalanceShortfallError,
     PolicyContext,
     PolicyViolationError,
+    ReasonCode,
     add_response_cost,
 )
 from syft_space.components.policy_types.prepaid.payment_policy import (
@@ -41,10 +42,9 @@ class PrepaidBalancePerRequestPolicy(PrepaidBalancePaymentPolicyBase):
             raise PolicyViolationError(
                 message=message,
                 policy_type=self.NAME,
-                outcome="policy_violation",
                 metadata_entry=self._rejected_entry(
                     context,
-                    reason_code="NO_PRICING_TIER",
+                    reason_code=ReasonCode.NO_PRICING_TIER,
                     reason=message,
                 ),
             )
@@ -67,10 +67,9 @@ class PrepaidBalancePerRequestPolicy(PrepaidBalancePaymentPolicyBase):
                     "price": price,
                     "currency": exc.currency,
                 },
-                outcome="policy_violation",
                 metadata_entry=self._rejected_entry(
                     context,
-                    reason_code="INSUFFICIENT_BALANCE",
+                    reason_code=ReasonCode.INSUFFICIENT_BALANCE,
                     reason=message,
                     amount=price,
                     currency=exc.currency,

--- a/backend/syft_space/components/policy_types/prepaid/per_request.py
+++ b/backend/syft_space/components/policy_types/prepaid/per_request.py
@@ -37,9 +37,16 @@ class PrepaidBalancePerRequestPolicy(PrepaidBalancePaymentPolicyBase):
         price = self._find_matching_price(user_email, configs)
 
         if price is None:
+            message = "No pricing tier matches your account"
             raise PolicyViolationError(
-                message="No pricing tier matches your account",
+                message=message,
                 policy_type=self.NAME,
+                outcome="policy_violation",
+                metadata_entry=self._rejected_entry(
+                    context,
+                    reason_code="NO_PRICING_TIER",
+                    reason=message,
+                ),
             )
 
         charger = context.payment_chargers.prepaid()
@@ -51,14 +58,23 @@ class PrepaidBalancePerRequestPolicy(PrepaidBalancePaymentPolicyBase):
                 charge_quantity=1,
             )
         except BalanceShortfallError as exc:
+            message = "Insufficient balance. Please purchase more credits."
             raise PolicyViolationError(
-                message="Insufficient balance. Please purchase more credits.",
+                message=message,
                 policy_type=self.NAME,
                 details={
                     "user": user_email,
                     "price": price,
                     "currency": exc.currency,
                 },
+                outcome="policy_violation",
+                metadata_entry=self._rejected_entry(
+                    context,
+                    reason_code="INSUFFICIENT_BALANCE",
+                    reason=message,
+                    amount=price,
+                    currency=exc.currency,
+                ),
             ) from exc
 
         # Generic key — metadata is scoped to this policy invocation.
@@ -92,11 +108,28 @@ class PrepaidBalancePerRequestPolicy(PrepaidBalancePaymentPolicyBase):
 
         if has_summary or has_documents:
             add_response_cost(response, price, charger.currency)
+            context.add_policy_metadata(
+                self._charged_entry(
+                    context,
+                    amount=price,
+                    currency=charger.currency,
+                    wallet_type=charger.wallet_type,
+                    transaction_id=transaction_id,
+                )
+            )
             return context
 
         # Cancel the reservation since the response is empty. Record zero
         # so consumers see this policy applied with no net charge.
         await charger.cancel(transaction_id)
         add_response_cost(response, 0, charger.currency)
+        context.add_policy_metadata(
+            self._refunded_entry(
+                context,
+                currency=charger.currency,
+                wallet_type=charger.wallet_type,
+                transaction_id=transaction_id,
+            )
+        )
 
         return context

--- a/backend/syft_space/components/policy_types/rate_limit/rate_limit_type.py
+++ b/backend/syft_space/components/policy_types/rate_limit/rate_limit_type.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field, field_validator
 from syft_space.components.policy_types.interfaces import (
     BasePolicyType,
     PolicyContext,
+    PolicyMetadataEntry,
     PolicyViolationError,
 )
 from syft_space.components.policy_types.rate_limit.limiter import (
@@ -207,12 +208,13 @@ class EndpointRateLimitPolicy(BasePolicyType):
             if not is_allowed:
                 friendly_limit = config.get_friendly_description()
                 _, reset_seconds = get_rate_limit_stats(key, count, window_seconds)
+                message = (
+                    f"Rate limit exceeded: {friendly_limit}. "
+                    f"Requests in window: {current_count}. "
+                    f"Try again in {reset_seconds}s."
+                )
                 raise PolicyViolationError(
-                    message=(
-                        f"Rate limit exceeded: {friendly_limit}. "
-                        f"Requests in window: {current_count}. "
-                        f"Try again in {reset_seconds}s."
-                    ),
+                    message=message,
                     policy_type=self.NAME,
                     details={
                         "limit": config.limit,
@@ -220,7 +222,25 @@ class EndpointRateLimitPolicy(BasePolicyType):
                         "reset_seconds": reset_seconds,
                         "scope": config.scope.value,
                     },
+                    outcome="rate_limited",
+                    metadata_entry=PolicyMetadataEntry(
+                        policy_type=self.NAME,
+                        kind="rate_limit",
+                        status="rejected",
+                        reason_code="RATE_LIMITED",
+                        reason=message,
+                        details={
+                            "limit": config.limit,
+                            "remaining": 0,
+                            "reset_seconds": reset_seconds,
+                            "scope": config.scope.value,
+                        },
+                    ),
                 )
+
+            # Within limit — no metadata entry. Emitting an "applied" entry on
+            # every allowed request pollutes the SDK-surfaced billing list; we
+            # only record an entry when the limit actually blocks (rejected).
 
         return context
 

--- a/backend/syft_space/components/policy_types/rate_limit/rate_limit_type.py
+++ b/backend/syft_space/components/policy_types/rate_limit/rate_limit_type.py
@@ -10,7 +10,9 @@ from syft_space.components.policy_types.interfaces import (
     BasePolicyType,
     PolicyContext,
     PolicyMetadataEntry,
+    PolicyRejection,
     PolicyViolationError,
+    ReasonCode,
 )
 from syft_space.components.policy_types.rate_limit.limiter import (
     check_rate_limit,
@@ -222,12 +224,12 @@ class EndpointRateLimitPolicy(BasePolicyType):
                         "reset_seconds": reset_seconds,
                         "scope": config.scope.value,
                     },
-                    outcome="rate_limited",
+                    outcome=PolicyRejection.RATE_LIMITED,
                     metadata_entry=PolicyMetadataEntry(
                         policy_type=self.NAME,
                         kind="rate_limit",
                         status="rejected",
-                        reason_code="RATE_LIMITED",
+                        reason_code=ReasonCode.RATE_LIMITED,
                         reason=message,
                         details={
                             "limit": config.limit,

--- a/backend/syft_space/main.py
+++ b/backend/syft_space/main.py
@@ -153,7 +153,6 @@ from syft_space.components.wallets.handlers import WalletHandler
 from syft_space.components.wallets.mpp.provider import MppWalletProvider
 from syft_space.components.wallets.repository import WalletRepository
 from syft_space.components.wallets.routes import build_wallet_routes
-
 from syft_space.config import app_settings
 
 
@@ -615,6 +614,7 @@ query_endpoint_handler = QueryEndpointHandler(
     wallet_repository=wallet_repository,
     balance_service=balance_service,
     event_reporter=report_query_event,
+    marketplace_repository=marketplace_repository,
 )
 publish_endpoint_handler = PublishEndpointHandler(
     endpoint_repository=endpoint_repository,

--- a/backend/tests/components/endpoints/test_policy_metadata.py
+++ b/backend/tests/components/endpoints/test_policy_metadata.py
@@ -1,0 +1,118 @@
+"""Tests for the policy-metadata contract on the query response (OME-285).
+
+Covers the producer side: the success envelope serialization and the two
+rejection rails (402 payment / 403 policy-violation) both carrying the same
+`policy_metadata` envelope via QueryRejectedError.
+"""
+
+from syft_space.components.endpoints.interfaces import QueryOutcome
+from syft_space.components.endpoints.query_handler import QueryEndpointHandler
+from syft_space.components.endpoints.schemas import QueryEndpointResponse
+from syft_space.components.policy_types.interfaces import (
+    PaymentRequiredError,
+    PolicyMetadata,
+    PolicyMetadataEntry,
+    PolicyViolationError,
+    Recipient,
+    TransactionRef,
+)
+
+
+def _handler() -> QueryEndpointHandler:
+    # The rejection helpers only use the passed exception, never self state,
+    # so None dependencies are fine for this unit.
+    return QueryEndpointHandler(
+        endpoint_repository=None,  # type: ignore[arg-type]
+        dataset_repository=None,  # type: ignore[arg-type]
+        model_repository=None,  # type: ignore[arg-type]
+        policy_repository=None,  # type: ignore[arg-type]
+        dataset_registry=None,  # type: ignore[arg-type]
+        model_registry=None,  # type: ignore[arg-type]
+        policy_registry=None,  # type: ignore[arg-type]
+    )
+
+
+def test_success_envelope_serializes_on_response() -> None:
+    entry = PolicyMetadataEntry(
+        policy_type="mpp_per_request",
+        kind="payment",
+        status="charged",
+        amount=0.01,
+        currency="USD",
+        recipient=Recipient(username="alice", wallet_address="0xabc"),
+        transaction=TransactionRef(rail="mpp", id="0xdeadbeef", reference="ext-1"),
+    )
+    meta = PolicyMetadata(outcome=QueryOutcome.SUCCESS.value, entries=[entry])
+    resp = QueryEndpointResponse(cost=0.01, currency="USD", policy_metadata=meta)
+
+    dumped = resp.model_dump()
+    assert dumped["policy_metadata"]["outcome"] == "success"
+    e = dumped["policy_metadata"]["entries"][0]
+    assert e["status"] == "charged"
+    assert e["transaction"] == {"rail": "mpp", "id": "0xdeadbeef", "reference": "ext-1"}
+    assert e["recipient"]["username"] == "alice"
+
+
+def test_reject_payment_envelope_402() -> None:
+    entry = PolicyMetadataEntry(
+        policy_type="mpp_per_request",
+        kind="payment",
+        status="rejected",
+        amount=0.01,
+        currency="USD",
+        reason_code="PAYMENT_REQUIRED",
+        reason="Payment of $0.01 required",
+    )
+    err = PaymentRequiredError(
+        www_authenticate='MPP realm="alice/x" amount=0.01',
+        description="Payment of $0.01 required",
+        metadata_entry=entry,
+    )
+    rejected = _handler()._reject_payment(err)
+
+    assert rejected.status_code == 402
+    assert rejected.headers == {"WWW-Authenticate": 'MPP realm="alice/x" amount=0.01'}
+    assert rejected.policy_metadata.outcome == "payment_required"
+    assert rejected.policy_metadata.entries[0].reason_code == "PAYMENT_REQUIRED"
+
+
+def test_reject_violation_envelope_403_insufficient_balance() -> None:
+    entry = PolicyMetadataEntry(
+        policy_type="xendit_per_request",
+        kind="payment",
+        status="rejected",
+        amount=500.0,
+        currency="IDR",
+        reason_code="INSUFFICIENT_BALANCE",
+        reason="Insufficient balance. Please purchase more credits.",
+    )
+    err = PolicyViolationError(
+        "Insufficient balance. Please purchase more credits.",
+        policy_type="xendit_per_request",
+        outcome="policy_violation",
+        metadata_entry=entry,
+    )
+    rejected = _handler()._reject_violation(err)
+
+    assert rejected.status_code == 403
+    assert rejected.headers is None
+    assert rejected.policy_metadata.outcome == "policy_violation"
+    assert rejected.policy_metadata.entries[0].reason_code == "INSUFFICIENT_BALANCE"
+
+
+def test_reject_violation_access_denied_outcome() -> None:
+    err = PolicyViolationError(
+        "Access denied",
+        policy_type="access",
+        outcome="access_denied",
+        metadata_entry=PolicyMetadataEntry(
+            policy_type="access",
+            kind="access",
+            status="rejected",
+            reason_code="ACCESS_DENIED",
+        ),
+    )
+    rejected = _handler()._reject_violation(err)
+    assert rejected.status_code == 403
+    assert rejected.policy_metadata.outcome == "access_denied"
+    assert rejected.policy_metadata.entries[0].kind == "access"

--- a/backend/tests/components/endpoints/test_policy_metadata.py
+++ b/backend/tests/components/endpoints/test_policy_metadata.py
@@ -1,4 +1,4 @@
-"""Tests for the policy-metadata contract on the query response (OME-285).
+"""Tests for the policy-metadata contract on the query response.
 
 Covers the producer side: the success envelope serialization and the two
 rejection rails (402 payment / 403 policy-violation) both carrying the same
@@ -6,30 +6,27 @@ rejection rails (402 payment / 403 policy-violation) both carrying the same
 """
 
 from syft_space.components.endpoints.interfaces import QueryOutcome
-from syft_space.components.endpoints.query_handler import QueryEndpointHandler
-from syft_space.components.endpoints.schemas import QueryEndpointResponse
+from syft_space.components.endpoints.query_handler import QueryRejectedError
+from syft_space.components.endpoints.schemas import (
+    PolicyMetadata,
+    QueryEndpointResponse,
+)
 from syft_space.components.policy_types.interfaces import (
     PaymentRequiredError,
-    PolicyMetadata,
     PolicyMetadataEntry,
+    PolicyRejection,
     PolicyViolationError,
+    ReasonCode,
     Recipient,
     TransactionRef,
 )
 
 
-def _handler() -> QueryEndpointHandler:
-    # The rejection helpers only use the passed exception, never self state,
-    # so None dependencies are fine for this unit.
-    return QueryEndpointHandler(
-        endpoint_repository=None,  # type: ignore[arg-type]
-        dataset_repository=None,  # type: ignore[arg-type]
-        model_repository=None,  # type: ignore[arg-type]
-        policy_repository=None,  # type: ignore[arg-type]
-        dataset_registry=None,  # type: ignore[arg-type]
-        model_registry=None,  # type: ignore[arg-type]
-        policy_registry=None,  # type: ignore[arg-type]
-    )
+def test_policy_rejection_subset_of_query_outcome() -> None:
+    """The handler coerces PolicyRejection -> QueryOutcome by value, so every
+    PolicyRejection value must have a QueryOutcome twin. Locks the invariant
+    that makes the boundary coercion total (no mapping table needed)."""
+    assert {r.value for r in PolicyRejection} <= {o.value for o in QueryOutcome}
 
 
 def test_success_envelope_serializes_on_response() -> None:
@@ -60,7 +57,7 @@ def test_reject_payment_envelope_402() -> None:
         status="rejected",
         amount=0.01,
         currency="USD",
-        reason_code="PAYMENT_REQUIRED",
+        reason_code=ReasonCode.PAYMENT_REQUIRED,
         reason="Payment of $0.01 required",
     )
     err = PaymentRequiredError(
@@ -68,7 +65,7 @@ def test_reject_payment_envelope_402() -> None:
         description="Payment of $0.01 required",
         metadata_entry=entry,
     )
-    rejected = _handler()._reject_payment(err)
+    rejected = QueryRejectedError.from_payment(err)
 
     assert rejected.status_code == 402
     assert rejected.headers == {"WWW-Authenticate": 'MPP realm="alice/x" amount=0.01'}
@@ -83,16 +80,16 @@ def test_reject_violation_envelope_403_insufficient_balance() -> None:
         status="rejected",
         amount=500.0,
         currency="IDR",
-        reason_code="INSUFFICIENT_BALANCE",
+        reason_code=ReasonCode.INSUFFICIENT_BALANCE,
         reason="Insufficient balance. Please purchase more credits.",
     )
     err = PolicyViolationError(
         "Insufficient balance. Please purchase more credits.",
         policy_type="xendit_per_request",
-        outcome="policy_violation",
+        outcome=PolicyRejection.POLICY_VIOLATION,
         metadata_entry=entry,
     )
-    rejected = _handler()._reject_violation(err)
+    rejected = QueryRejectedError.from_violation(err)
 
     assert rejected.status_code == 403
     assert rejected.headers is None
@@ -104,15 +101,44 @@ def test_reject_violation_access_denied_outcome() -> None:
     err = PolicyViolationError(
         "Access denied",
         policy_type="access",
-        outcome="access_denied",
+        outcome=PolicyRejection.ACCESS_DENIED,
         metadata_entry=PolicyMetadataEntry(
             policy_type="access",
             kind="access",
             status="rejected",
-            reason_code="ACCESS_DENIED",
+            reason_code=ReasonCode.ACCESS_DENIED,
         ),
     )
-    rejected = _handler()._reject_violation(err)
+    rejected = QueryRejectedError.from_violation(err)
     assert rejected.status_code == 403
     assert rejected.policy_metadata.outcome == "access_denied"
     assert rejected.policy_metadata.entries[0].kind == "access"
+
+
+def test_rejection_envelope_includes_prior_entries() -> None:
+    """A policy that already ran (e.g. charged) before a later policy rejects
+    must still appear in the rejection envelope — prior entries first, then
+    the rejecting policy's own entry."""
+    charged = PolicyMetadataEntry(
+        policy_type="xendit_per_request",
+        kind="payment",
+        status="charged",
+        amount=5.0,
+        currency="USD",
+    )
+    err = PolicyViolationError(
+        "Rate limit exceeded",
+        policy_type="rate_limit",
+        outcome=PolicyRejection.RATE_LIMITED,
+        metadata_entry=PolicyMetadataEntry(
+            policy_type="rate_limit",
+            kind="rate_limit",
+            status="rejected",
+            reason_code=ReasonCode.RATE_LIMITED,
+        ),
+    )
+    rejected = QueryRejectedError.from_violation(err, prior_entries=[charged])
+
+    assert rejected.policy_metadata.outcome == "rate_limited"
+    statuses = [e.status for e in rejected.policy_metadata.entries]
+    assert statuses == ["charged", "rejected"]


### PR DESCRIPTION
## Summary

Implements **OME-285**: every endpoint query response now carries a structured `policy_metadata` envelope — on success **and** on 402/403 rejection — so SDK clients receive authoritative payment/policy metadata (price, recipient, rail-native transaction id, status, rejection reason) instead of reconstructing it from policy configs.

This is the **producer** side of the contract. The consumer side (aggregator + Python SDK, OME-284) is in a paired PR on `OpenMined/syfthub` (`feat/policy-metadata-response`).

## What's included

- New models in `policy_types/interfaces.py`: `PolicyMetadata`, `PolicyMetadataEntry`, `TransactionRef` (rail-native id + `rail` discriminator), `Recipient`.
- `QueryEndpointResponse` gains `policy_metadata`; `QueryOutcome` gains `access_denied` / `rate_limited`.
- **General per-policy framework**: MPP, prepaid (xendit/stripe), access, rate_limit and pii_filter emit entries via shared base-class helpers (`_charged_entry` / `_free_entry` / `_rejected_entry` / `_refunded_entry`).
- `QueryRejectedError` funnels 402/403 with the same envelope (single route branch); rejections are converted once in the handler so a raise from anywhere can't 500.
- Lazy recipient resolution (no marketplace DB lookup on free/non-payment endpoints).
- `_safe_outcome` maps unknown outcome strings instead of raising.
- The `Payment-Receipt` header is removed — the receipt now lives in `policy_metadata.entries[].transaction.id`.

## Decisions
- **Transaction id**: rail-native id + `rail` discriminator (Tempo tx hash for MPP, ledger UUID for prepaid).
- **No backward compatibility** — old paths removed rather than dual-branched.

## Testing
- New `tests/components/endpoints/test_policy_metadata.py` covers the success + payment/violation/access-denied rejection envelopes.
- ruff + mypy clean on changed files; existing pii_filter tests pass.

## Reviewer notes
A high-effort multi-agent review was run on this change; all surfaced correctness findings (e.g. `TransactionRef` None-guard, `QueryOutcome` ValueError guard, rejection-from-anywhere handling) are addressed in this PR.