### PR TITLE
feat(endpoints): editable system_prompt for model-backed endpoints

### DIFF
--- a/backend/syft_space/components/endpoints/handlers.py
+++ b/backend/syft_space/components/endpoints/handlers.py
@@ -110,6 +110,7 @@ class EndpointHandler:
             name=request.name,
             summary=request.summary,
             description=request.description,
+            system_prompt=request.system_prompt,
         )
         if not updated_endpoint:
             raise HTTPException(status_code=404, detail=f"Endpoint '{slug}' not found")

--- a/frontend/src/components/EditEndpointDialog.vue
+++ b/frontend/src/components/EditEndpointDialog.vue
@@ -74,6 +74,22 @@
             language="en-US"
           />
         </div>
+
+        <div v-if="endpoint?.model_id" class="space-y-2">
+          <Label for="edit-system-prompt" class="body-sm font-medium text-foreground">
+            System prompt
+          </Label>
+          <Textarea
+            id="edit-system-prompt"
+            v-model="localSystemPrompt"
+            placeholder="Enter a custom system prompt..."
+            class="min-h-[140px] font-mono body-sm"
+          />
+          <p class="body-sm text-muted-foreground">
+            Sent to the model before every query. Controls tone, format, and how retrieved documents
+            are used.
+          </p>
+        </div>
       </div>
       <DialogFooter>
         <Button variant="outline" @click="handleCancel" :disabled="isSaving">Cancel</Button>
@@ -95,6 +111,7 @@ import { Eye, Pencil } from 'lucide-vue-next'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
 import {
   Dialog,
   DialogContent,
@@ -113,6 +130,8 @@ interface EndpointData {
   name: string
   summary: string
   description?: string
+  model_id?: string
+  system_prompt?: string | null
 }
 
 const props = defineProps<{
@@ -122,13 +141,14 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   'update:open': [value: boolean]
-  saved: [data: { summary: string; description: string }]
+  saved: [data: { summary: string; description: string; system_prompt?: string | null }]
 }>()
 
 const { isDark } = useTheme()
 
 const localSummary = ref('')
 const localDescription = ref('')
+const localSystemPrompt = ref('')
 const isSaving = ref(false)
 const isPreviewMode = ref(false)
 
@@ -138,6 +158,7 @@ watch(
     if (newEndpoint) {
       localSummary.value = newEndpoint.summary
       localDescription.value = newEndpoint.description || ''
+      localSystemPrompt.value = newEndpoint.system_prompt || ''
       isPreviewMode.value = false
 
       if (!newEndpoint.description) {
@@ -145,6 +166,9 @@ watch(
           const fullEndpoint = await endpointsApi.get(newEndpoint.slug)
           if (fullEndpoint.description) {
             localDescription.value = fullEndpoint.description
+          }
+          if (newEndpoint.model_id) {
+            localSystemPrompt.value = fullEndpoint.system_prompt || ''
           }
         } catch (error) {
           console.error('Failed to fetch endpoint details:', error)
@@ -173,10 +197,14 @@ const handleSave = async () => {
 
   isSaving.value = true
 
+  const hasModel = !!props.endpoint.model_id
+  const systemPrompt = hasModel ? localSystemPrompt.value.trim() || null : undefined
+
   try {
     await endpointsApi.update(props.endpoint.slug, {
       summary: localSummary.value,
       description: localDescription.value || undefined,
+      ...(hasModel ? { system_prompt: systemPrompt } : {}),
     })
 
     await endpointsApi.publish(props.endpoint.slug, {
@@ -186,6 +214,7 @@ const handleSave = async () => {
     emit('saved', {
       summary: localSummary.value,
       description: localDescription.value,
+      ...(hasModel ? { system_prompt: systemPrompt } : {}),
     })
 
     emit('update:open', false)

--- a/frontend/src/pages/EndpointDetailPage.vue
+++ b/frontend/src/pages/EndpointDetailPage.vue
@@ -1056,6 +1056,8 @@ const endpointForEdit = computed(() => {
     name: endpoint.value.name,
     summary: endpoint.value.summary,
     description: endpoint.value.description,
+    model_id: endpoint.value.model_id ?? endpoint.value.model?.id,
+    system_prompt: endpoint.value.system_prompt,
   }
 })
 
@@ -1072,10 +1074,17 @@ const openDeleteDialog = () => {
   showDeleteDialog.value = true
 }
 
-const handleEditSaved = (data: { summary: string; description: string }) => {
+const handleEditSaved = (data: {
+  summary: string
+  description: string
+  system_prompt?: string | null
+}) => {
   if (endpoint.value) {
     endpoint.value.summary = data.summary
     endpoint.value.description = data.description
+    if (data.system_prompt !== undefined) {
+      endpoint.value.system_prompt = data.system_prompt
+    }
   }
 }
 

--- a/frontend/src/pages/EndpointsPage.vue
+++ b/frontend/src/pages/EndpointsPage.vue
@@ -244,7 +244,13 @@ const deleteNameConfirm = ref('')
 const isDeleting = ref(false)
 
 const showEditDialog = ref(false)
-const endpointToEdit = ref<{ slug: string; name: string; summary: string } | null>(null)
+const endpointToEdit = ref<{
+  slug: string
+  name: string
+  summary: string
+  model_id?: string
+  system_prompt?: string | null
+} | null>(null)
 
 const classifyEndpoint = (e: EndpointItem): Exclude<FilterValue, 'all'> | 'unknown' => {
   const hasDataset = !!e.datasetId
@@ -311,15 +317,24 @@ const handleEditEndpoint = (endpoint: EndpointItem) => {
     slug: endpoint.slug,
     name: endpoint.name,
     summary: endpoint.summary,
+    model_id: endpoint.modelId,
+    system_prompt: endpoint.systemPrompt,
   }
   showEditDialog.value = true
 }
 
-const handleEditSaved = (data: { summary: string }) => {
+const handleEditSaved = (data: {
+  summary: string
+  description: string
+  system_prompt?: string | null
+}) => {
   if (endpointToEdit.value) {
     const index = endpointsStore.endpoints.findIndex((e) => e.slug === endpointToEdit.value!.slug)
     if (index > -1 && endpointsStore.endpoints[index]) {
       endpointsStore.endpoints[index].summary = data.summary
+      if (data.system_prompt !== undefined) {
+        endpointsStore.endpoints[index].systemPrompt = data.system_prompt
+      }
     }
   }
   endpointToEdit.value = null

--- a/frontend/src/pages/GoLivePage.vue
+++ b/frontend/src/pages/GoLivePage.vue
@@ -128,7 +128,17 @@ const toggleDataSource = (id: string) => {
 }
 
 const toggleModel = (id: string) => {
-  selectedModelId.value = selectedModelId.value === id ? '' : id
+  const selecting = selectedModelId.value !== id
+  selectedModelId.value = selecting ? id : ''
+  if (selecting) {
+    if (!systemPrompt.value) {
+      selectedPromptPreset.value = 'summarise-cite'
+      systemPrompt.value = PROMPT_PRESETS['summarise-cite']?.prompt ?? ''
+    }
+  } else {
+    selectedPromptPreset.value = 'summarise-cite'
+    systemPrompt.value = ''
+  }
 }
 
 const showCreateDatasetDialog = ref(false)
@@ -808,6 +818,36 @@ const handleOverwriteConfirm = async () => {
                     <Plus class="h-5 w-5 shrink-0" />
                     <span class="text-sm font-medium">Add model</span>
                   </button>
+                </div>
+
+                <!-- System prompt (shown once a model is attached) -->
+                <div v-if="selectedModelId" class="mt-6 space-y-3">
+                  <div class="flex items-center gap-2">
+                    <Sparkles class="h-4 w-4 text-muted-foreground" />
+                    <h4 class="text-sm font-semibold text-foreground">System prompt</h4>
+                  </div>
+                  <Select
+                    :model-value="selectedPromptPreset"
+                    @update:model-value="handlePromptPresetChange"
+                  >
+                    <SelectTrigger class="w-full">
+                      <SelectValue placeholder="Choose a prompt template" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem v-for="(preset, key) in PROMPT_PRESETS" :key="key" :value="key">
+                        {{ preset.label }}
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <Textarea
+                    v-model="systemPrompt"
+                    placeholder="Enter a custom system prompt..."
+                    class="min-h-[140px] font-mono text-sm"
+                  />
+                  <p class="text-[11px] text-muted-foreground">
+                    Sent to the model before every query. Controls tone, format, and how retrieved
+                    documents are used.
+                  </p>
                 </div>
               </div>
             </template>


### PR DESCRIPTION
This pull request adds support for editing and managing a custom "system prompt" for endpoints that have an associated model. The system prompt can now be set, updated, and displayed in both the endpoint creation/editing dialogs and the Go Live workflow. The changes ensure that the prompt is properly handled in the frontend state, API calls, and backend update logic.

**System Prompt Support for Endpoints with Models**

* Added a `system_prompt` field to the endpoint edit dialog, allowing users to set or update the system prompt for endpoints with a model (`EditEndpointDialog.vue`, `EndpointsPage.vue`, `EndpointDetailPage.vue`). [[1]](diffhunk://#diff-bf43791e5b7811a8f3cdb4b5847d4fb49adcd109b956e1e0b87d08685ae2e752R77-R92) [[2]](diffhunk://#diff-bf43791e5b7811a8f3cdb4b5847d4fb49adcd109b956e1e0b87d08685ae2e752R133-R134) [[3]](diffhunk://#diff-bf43791e5b7811a8f3cdb4b5847d4fb49adcd109b956e1e0b87d08685ae2e752L125-R151) [[4]](diffhunk://#diff-bf43791e5b7811a8f3cdb4b5847d4fb49adcd109b956e1e0b87d08685ae2e752R161) [[5]](diffhunk://#diff-bf43791e5b7811a8f3cdb4b5847d4fb49adcd109b956e1e0b87d08685ae2e752R170-R172) [[6]](diffhunk://#diff-bf43791e5b7811a8f3cdb4b5847d4fb49adcd109b956e1e0b87d08685ae2e752R200-R207) [[7]](diffhunk://#diff-bf43791e5b7811a8f3cdb4b5847d4fb49adcd109b956e1e0b87d08685ae2e752R217) [[8]](diffhunk://#diff-daa6cafed790263f875ce2f9ae7781737b1a3c47f2a9c3fb87b999bfa5665b15L247-R253) [[9]](diffhunk://#diff-daa6cafed790263f875ce2f9ae7781737b1a3c47f2a9c3fb87b999bfa5665b15R320-R337) [[10]](diffhunk://#diff-a9bdd2e05a5fe66101a4b43eb1e6d7586977fa1851dc39a2e0fce4cacf05516dR1059-R1060) [[11]](diffhunk://#diff-a9bdd2e05a5fe66101a4b43eb1e6d7586977fa1851dc39a2e0fce4cacf05516dL1075-R1087)

* Updated the backend endpoint update handler to accept and persist the `system_prompt` value (`handlers.py`).

**Go Live Workflow Enhancements**

* Added UI for selecting a prompt preset and customizing the system prompt when attaching a model during the Go Live process. The system prompt is now initialized/reset appropriately when selecting or deselecting a model (`GoLivePage.vue`). [[1]](diffhunk://#diff-62c370bf2308515714309d69259dde2248b96acf9a49f2b54beebf115caf243eL131-R141) [[2]](diffhunk://#diff-62c370bf2308515714309d69259dde2248b96acf9a49f2b54beebf115caf243eR822-R851)

These changes improve the flexibility and control users have over how their endpoints interact with models, by allowing custom instructions to be sent with every query.