### PR TITLE
Enhance summary endpoints with dataset retrieval and validation

### DIFF
--- a/backend/syft_space/components/endpoints/entities.py
+++ b/backend/syft_space/components/endpoints/entities.py
@@ -20,8 +20,26 @@ class ResponseType(str, Enum):
     """Type of response for an endpoint."""
 
     RAW = "raw"  # Only dataset search results
-    SUMMARY = "summary"  # Only model chat results
+    SUMMARY = "summary"  # Only model chat results (dataset optional, as RAG grounding)
     BOTH = "both"  # Both dataset search + model chat
+
+
+def validate_response_type_attachments(
+    response_type: ResponseType, *, has_dataset: bool, has_model: bool
+) -> str | None:
+    """Return an error message when the attachments can't serve the response type.
+
+    ``raw`` needs a dataset, ``summary`` needs a model (dataset optional, as
+    RAG grounding), ``both`` needs both. Enforced at endpoint creation only;
+    pre-existing endpoints keep their legacy query behavior.
+    """
+    if response_type is ResponseType.RAW and not has_dataset:
+        return "response_type 'raw' requires a dataset_id"
+    if response_type is ResponseType.SUMMARY and not has_model:
+        return "response_type 'summary' requires a model_id"
+    if response_type is ResponseType.BOTH and not (has_dataset and has_model):
+        return "response_type 'both' requires both a dataset_id and a model_id"
+    return None
 
 
 class Endpoint(SQLModel, table=True):

--- a/backend/syft_space/components/endpoints/handlers.py
+++ b/backend/syft_space/components/endpoints/handlers.py
@@ -54,14 +54,11 @@ class EndpointHandler:
     async def create_endpoint(
         self, request: CreateEndpointRequest, tenant: Tenant
     ) -> EndpointCreateResponse:
-        """Create a new endpoint."""
-        # Validate at least one of dataset_id or model_id is provided
-        if request.dataset_id is None and request.model_id is None:
-            raise HTTPException(
-                status_code=400,
-                detail="At least one of dataset_id or model_id must be provided",
-            )
+        """Create a new endpoint.
 
+        The response_type/attachment invariant is enforced by
+        ``CreateEndpointRequest`` validators.
+        """
         # Check if slug already exists within tenant
         existing = await self.endpoint_repository.get_by_slug(request.slug, tenant.id)
         if existing:

--- a/backend/syft_space/components/endpoints/query_handler.py
+++ b/backend/syft_space/components/endpoints/query_handler.py
@@ -267,9 +267,11 @@ class QueryEndpointHandler:
 
             response_type = ResponseType(endpoint.response_type)
 
-            # Search dataset if needed
+            # Search dataset if needed. For SUMMARY the references only
+            # ground the model; they are stripped from the response below.
             if (
-                response_type in [ResponseType.RAW, ResponseType.BOTH]
+                response_type
+                in [ResponseType.RAW, ResponseType.SUMMARY, ResponseType.BOTH]
                 and endpoint.dataset_id
             ):
                 # Pass the query through unchanged for retrieval. The
@@ -317,6 +319,12 @@ class QueryEndpointHandler:
 
             # Attach the success policy_metadata envelope onto the response.
             response_dict = policy_context.response or {}
+
+            # Stripped only after post-hooks so per-document policies could
+            # charge for the retrieved references.
+            if response_type == ResponseType.SUMMARY:
+                response_dict["references"] = None
+
             response_dict["policy_metadata"] = PolicyMetadata(
                 outcome=QueryOutcome.SUCCESS,
                 entries=policy_context.policy_metadata,

--- a/backend/syft_space/components/endpoints/schemas.py
+++ b/backend/syft_space/components/endpoints/schemas.py
@@ -16,7 +16,10 @@ from pydantic import (
 from syft_space.components.dataset_types.redaction import (
     redact_config as redact_dataset_config,
 )
-from syft_space.components.endpoints.entities import ResponseType
+from syft_space.components.endpoints.entities import (
+    ResponseType,
+    validate_response_type_attachments,
+)
 from syft_space.components.endpoints.interfaces import QueryOutcome
 from syft_space.components.model_types.redaction import (
     redact_config as redact_model_config,
@@ -94,6 +97,31 @@ class CreateEndpointRequest(BaseModel):
             )
 
         return _slug
+
+    @field_validator("response_type")
+    @classmethod
+    def validate_response_type(cls, v: str) -> str:
+        """Validate the response type."""
+        try:
+            ResponseType(v)
+        except ValueError:
+            valid = ", ".join(rt.value for rt in ResponseType)
+            raise ValueError(
+                f"Invalid response_type '{v}'. Must be one of: {valid}"
+            ) from None
+        return v
+
+    @model_validator(mode="after")
+    def validate_attachments(self) -> "CreateEndpointRequest":
+        """Validate the attachments can serve the response type."""
+        error = validate_response_type_attachments(
+            ResponseType(self.response_type),
+            has_dataset=self.dataset_id is not None,
+            has_model=self.model_id is not None,
+        )
+        if error:
+            raise ValueError(error)
+        return self
 
     class Config:
         """Pydantic config."""

--- a/backend/tests/components/endpoints/test_response_type_flow.py
+++ b/backend/tests/components/endpoints/test_response_type_flow.py
@@ -1,0 +1,197 @@
+"""Tests for the per-response-type query flow in ``query_endpoint``.
+
+Locks the retrieval/chat gating contract:
+
+- ``raw``     -> dataset search only; references returned, no model call.
+- ``summary`` -> dataset search feeds the model as RAG context, but the
+                 references are stripped from the user-facing response.
+- ``both``    -> dataset search + model chat; both returned.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from syft_space.components.endpoints.entities import Endpoint
+from syft_space.components.endpoints.query_handler import QueryEndpointHandler
+from syft_space.components.endpoints.schemas import AuthenticatedQueryRequest
+from syft_space.components.model_types.interfaces import (
+    ChatMessageResult,
+    ChatResult,
+    TokenUsage,
+)
+from syft_space.components.shared.search_types import SearchedDocument, SearchResult
+
+TENANT_ID = uuid4()
+DATASET_ID = uuid4()
+MODEL_ID = uuid4()
+
+
+def _make_chat_result() -> ChatResult:
+    return ChatResult(
+        id="chat-test-id",
+        model="test-model",
+        messages=[ChatMessageResult(role="assistant", content="answer", tokens=1)],
+        finish_reason="stop",
+        usage=TokenUsage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+    )
+
+
+def _make_search_result() -> SearchResult:
+    return SearchResult(
+        documents=[
+            SearchedDocument(
+                document_id="doc-1",
+                content="retrieved paper content",
+                similarity_score=0.9,
+            )
+        ]
+    )
+
+
+def _make_endpoint(response_type: str) -> Endpoint:
+    return Endpoint(
+        name="ep",
+        slug="ep",
+        tenant_id=TENANT_ID,
+        dataset_id=DATASET_ID,
+        model_id=MODEL_ID,
+        response_type=response_type,
+        published=True,
+    )
+
+
+def _make_handler(
+    endpoint: Endpoint,
+) -> tuple[QueryEndpointHandler, MagicMock, MagicMock]:
+    """Build a handler with a mocked pipeline for ``endpoint``.
+
+    Returns (handler, dataset_instance, model_instance) so tests can assert
+    on search/chat calls.
+    """
+    endpoint_repository = MagicMock()
+    endpoint_repository.get_by_slug = AsyncMock(return_value=endpoint)
+
+    policy_repository = MagicMock()
+    policy_repository.get_by_endpoint_id_grouped = AsyncMock(return_value={})
+
+    dataset = SimpleNamespace(
+        id=DATASET_ID, tenant_id=TENANT_ID, dtype="chroma", configuration={}
+    )
+    dataset_repository = MagicMock()
+    dataset_repository.get_by_id = AsyncMock(return_value=dataset)
+
+    dataset_instance = MagicMock()
+    dataset_instance.search = AsyncMock(return_value=_make_search_result())
+    dataset_registry = MagicMock()
+    dataset_registry.get_dataset_type = MagicMock(
+        return_value=MagicMock(return_value=dataset_instance)
+    )
+
+    model = SimpleNamespace(
+        id=MODEL_ID, tenant_id=TENANT_ID, dtype="openai", configuration={}
+    )
+    model_repository = MagicMock()
+    model_repository.get_by_id = AsyncMock(return_value=model)
+
+    model_instance = MagicMock()
+    model_instance.chat = AsyncMock(return_value=_make_chat_result())
+    model_instance.aclose = AsyncMock()
+    model_registry = MagicMock()
+    model_registry.get_model_type = MagicMock(
+        return_value=MagicMock(return_value=model_instance)
+    )
+
+    handler = QueryEndpointHandler(
+        endpoint_repository=endpoint_repository,
+        dataset_repository=dataset_repository,
+        model_repository=model_repository,
+        policy_repository=policy_repository,
+        dataset_registry=dataset_registry,
+        model_registry=model_registry,
+        policy_registry=MagicMock(),
+    )
+    return handler, dataset_instance, model_instance
+
+
+def _make_request() -> AuthenticatedQueryRequest:
+    return AuthenticatedQueryRequest(
+        messages="what do the papers say?",
+        sender_email="user@example.com",
+    )
+
+
+@pytest.mark.asyncio
+async def test_raw_searches_dataset_and_skips_model() -> None:
+    endpoint = _make_endpoint("raw")
+    handler, dataset_instance, model_instance = _make_handler(endpoint)
+    tenant = SimpleNamespace(id=TENANT_ID)
+
+    response = await handler.query_endpoint("ep", _make_request(), tenant)
+
+    dataset_instance.search.assert_awaited_once()
+    model_instance.chat.assert_not_awaited()
+    assert response.summary is None
+    assert response.references is not None
+    assert response.references.documents[0].document_id == "doc-1"
+
+
+@pytest.mark.asyncio
+async def test_summary_retrieves_and_feeds_model_but_strips_references() -> None:
+    """SUMMARY must ground the model in the dataset without exposing it."""
+    endpoint = _make_endpoint("summary")
+    handler, dataset_instance, model_instance = _make_handler(endpoint)
+    tenant = SimpleNamespace(id=TENANT_ID)
+
+    response = await handler.query_endpoint("ep", _make_request(), tenant)
+
+    dataset_instance.search.assert_awaited_once()
+    model_instance.chat.assert_awaited_once()
+
+    # The retrieved document must be injected as RAG context for the model.
+    _, messages_arg, _ = model_instance.chat.await_args.args
+    context_messages = [
+        m
+        for m in messages_arg
+        if m.role == "system" and "retrieved paper content" in m.content
+    ]
+    assert len(context_messages) == 1
+
+    # ...but the raw documents never leave the server.
+    assert response.summary is not None
+    assert response.summary.message.content == "answer"
+    assert response.references is None
+
+
+@pytest.mark.asyncio
+async def test_summary_without_dataset_skips_search() -> None:
+    endpoint = _make_endpoint("summary")
+    endpoint.dataset_id = None
+    handler, dataset_instance, model_instance = _make_handler(endpoint)
+    tenant = SimpleNamespace(id=TENANT_ID)
+
+    response = await handler.query_endpoint("ep", _make_request(), tenant)
+
+    dataset_instance.search.assert_not_awaited()
+    model_instance.chat.assert_awaited_once()
+    assert response.summary is not None
+    assert response.references is None
+
+
+@pytest.mark.asyncio
+async def test_both_returns_summary_and_references() -> None:
+    endpoint = _make_endpoint("both")
+    handler, dataset_instance, model_instance = _make_handler(endpoint)
+    tenant = SimpleNamespace(id=TENANT_ID)
+
+    response = await handler.query_endpoint("ep", _make_request(), tenant)
+
+    dataset_instance.search.assert_awaited_once()
+    model_instance.chat.assert_awaited_once()
+    assert response.summary is not None
+    assert response.references is not None
+    assert response.references.documents[0].document_id == "doc-1"

--- a/backend/tests/components/endpoints/test_response_type_validation.py
+++ b/backend/tests/components/endpoints/test_response_type_validation.py
@@ -1,0 +1,85 @@
+"""Tests for response_type/attachment validation on ``CreateEndpointRequest``.
+
+Creation is the only gate: ``raw`` needs a dataset, ``summary`` needs a
+model, ``both`` needs both. Endpoints created before this validation keep
+their legacy query behavior — the query path does not re-check.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from syft_space.components.endpoints.entities import (
+    ResponseType,
+    validate_response_type_attachments,
+)
+from syft_space.components.endpoints.schemas import CreateEndpointRequest
+
+
+@pytest.mark.parametrize(
+    ("response_type", "has_dataset", "has_model", "ok"),
+    [
+        (ResponseType.RAW, True, False, True),
+        (ResponseType.RAW, True, True, True),
+        (ResponseType.RAW, False, True, False),
+        (ResponseType.SUMMARY, False, True, True),
+        (ResponseType.SUMMARY, True, True, True),
+        (ResponseType.SUMMARY, True, False, False),
+        (ResponseType.BOTH, True, True, True),
+        (ResponseType.BOTH, True, False, False),
+        (ResponseType.BOTH, False, True, False),
+        (ResponseType.BOTH, False, False, False),
+    ],
+)
+def test_validate_response_type_attachments(
+    response_type: ResponseType, has_dataset: bool, has_model: bool, ok: bool
+) -> None:
+    error = validate_response_type_attachments(
+        response_type, has_dataset=has_dataset, has_model=has_model
+    )
+    assert (error is None) is ok
+
+
+def _create_request(**kwargs) -> CreateEndpointRequest:
+    return CreateEndpointRequest(name="test-ep", slug="test-ep", **kwargs)
+
+
+@pytest.mark.parametrize(
+    ("response_type", "attachments"),
+    [
+        ("raw", {"dataset_id": uuid4()}),
+        ("summary", {"model_id": uuid4()}),
+        ("summary", {"dataset_id": uuid4(), "model_id": uuid4()}),
+        ("both", {"dataset_id": uuid4(), "model_id": uuid4()}),
+    ],
+)
+def test_create_request_accepts_valid_attachments(
+    response_type: str, attachments: dict
+) -> None:
+    request = _create_request(response_type=response_type, **attachments)
+    assert request.response_type == response_type
+
+
+@pytest.mark.parametrize(
+    ("response_type", "attachments"),
+    [
+        ("raw", {"model_id": uuid4()}),
+        ("summary", {"dataset_id": uuid4()}),
+        ("both", {"dataset_id": uuid4()}),
+        ("both", {"model_id": uuid4()}),
+        ("both", {}),
+    ],
+)
+def test_create_request_rejects_attachments_that_cant_serve_response_type(
+    response_type: str, attachments: dict
+) -> None:
+    with pytest.raises(ValidationError, match=f"'{response_type}'"):
+        _create_request(response_type=response_type, **attachments)
+
+
+def test_create_request_rejects_unknown_response_type() -> None:
+    with pytest.raises(ValidationError, match="Invalid response_type"):
+        _create_request(response_type="summry", model_id=uuid4())


### PR DESCRIPTION
This pull request enforces and tests strict validation for endpoint creation based on the `response_type` and attached resources (dataset and/or model), and clarifies the behavior of each response type during query execution. It also adds comprehensive tests to ensure the correct gating and output for each response type, and that references are handled securely. The main changes are grouped below.

**Validation logic and enforcement:**

* Added the `validate_response_type_attachments` function in `entities.py` to ensure that `raw` endpoints require a dataset, `summary` endpoints require a model (dataset optional for RAG), and `both` endpoints require both; this validation is enforced during endpoint creation.
* Updated `CreateEndpointRequest` in `schemas.py` to validate `response_type` values and enforce the attachment rules via Pydantic validators, rejecting invalid combinations at creation time.
* Removed the now-redundant attachment validation from the handler, relying on schema-level validation instead.

**Query execution and response handling:**

* Clarified and enforced that for `summary` response type, dataset search results are used only as grounding for the model (RAG), and are stripped from the user-facing response after post-hooks, ensuring references are not leaked. [[1]](diffhunk://#diff-fbc0c0a5c6f5cc8384d2ded355a2da0a4dda6892de6d4c450e0b3c8f8e8200f4L270-R274) [[2]](diffhunk://#diff-fbc0c0a5c6f5cc8384d2ded355a2da0a4dda6892de6d4c450e0b3c8f8e8200f4R322-R327)

**Testing and contract locking:**

* Added `test_response_type_flow.py` to verify that each response type (`raw`, `summary`, `both`) triggers the correct pipeline (dataset/model) and that references are exposed or hidden as appropriate.
* Added `test_response_type_validation.py` to ensure endpoint creation validation strictly enforces the new rules and rejects invalid combinations or unknown response types.

**Imports and code organization:**

* Updated imports in `schemas.py` to include the new validation function.