### PR TITLE
Improve session management and error handling in SyftHub

### DIFF
--- a/backend/syft_space/components/analytics/entities.py
+++ b/backend/syft_space/components/analytics/entities.py
@@ -17,6 +17,8 @@ class QueryEventStatus(str, Enum):
     NOT_PUBLISHED = "not_published"
     PAYMENT_REQUIRED = "payment_required"
     POLICY_VIOLATION = "policy_violation"
+    ACCESS_DENIED = "access_denied"
+    RATE_LIMITED = "rate_limited"
     INTERNAL_ERROR = "internal_error"
 
 

--- a/backend/syft_space/components/endpoints/endpoint_heartbeat_manager.py
+++ b/backend/syft_space/components/endpoints/endpoint_heartbeat_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import random
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from uuid import UUID
@@ -55,6 +56,7 @@ class EndpointHeartbeatManager(LifecycleService):
 
     # Fixed health check interval
     CHECK_INTERVAL = 30.0  # Check + deliver every 30 seconds
+    JITTER_MAX = 5.0  # Random extra sleep so co-located instances desynchronize
     TTL_MULTIPLIER = 3.0  # TTL = 90s (3 missed checks before stale)
     POLL_INTERVAL = 5.0  # Poll for public_url every 5 seconds
 
@@ -172,7 +174,7 @@ class EndpointHeartbeatManager(LifecycleService):
 
                 try:
                     await asyncio.wait_for(
-                        self._shutdown_event.wait(), timeout=self._check_interval
+                        self._shutdown_event.wait(), timeout=self._jittered_interval()
                     )
                     break
                 except asyncio.TimeoutError:
@@ -184,13 +186,21 @@ class EndpointHeartbeatManager(LifecycleService):
                 logger.exception(f"Unexpected error in endpoint heartbeat loop: {e}")
                 try:
                     await asyncio.wait_for(
-                        self._shutdown_event.wait(), timeout=self._check_interval
+                        self._shutdown_event.wait(), timeout=self._jittered_interval()
                     )
                     break
                 except asyncio.TimeoutError:
                     pass
 
         logger.info("Endpoint heartbeat loop stopped")
+
+    def _jittered_interval(self) -> float:
+        """Check interval plus random jitter.
+
+        Co-located instances otherwise heartbeat in lockstep and hit the
+        marketplace's rate limiter together.
+        """
+        return self._check_interval + random.uniform(0.0, self.JITTER_MAX)  # nosec B311
 
     async def _wait_for_public_url(self) -> bool:
         """Wait for public_url to be set in settings.

--- a/backend/syft_space/components/endpoints/endpoint_heartbeat_manager.py
+++ b/backend/syft_space/components/endpoints/endpoint_heartbeat_manager.py
@@ -11,7 +11,11 @@ from loguru import logger
 
 from syft_space.components.marketplaces.entities import Marketplace
 from syft_space.components.shared.lifecycle import LifecycleService
-from syft_space.components.shared.syfthub_client import SyftHubClient, SyftHubError
+from syft_space.components.shared.syfthub_client import (
+    RateLimitError,
+    SyftHubClient,
+    SyftHubError,
+)
 
 if TYPE_CHECKING:
     from syft_space.components.marketplaces.repository import MarketplaceRepository
@@ -307,6 +311,13 @@ class EndpointHeartbeatManager(LifecycleService):
                     f"{len(endpoint_health)} endpoints, ttl={ttl}s"
                 )
 
+        except RateLimitError as e:
+            self._handle_transport_failure(state, now, immediate=True)
+            logger.warning(
+                f"Endpoint heartbeat to {marketplace.name} rate limited, "
+                f"backing off {state.next_delivery_at - now:.0f}s: {e.message} "
+                f"(failures={state.consecutive_failures})"
+            )
         except SyftHubError as e:
             self._handle_transport_failure(state, now)
             logger.warning(
@@ -329,20 +340,27 @@ class EndpointHeartbeatManager(LifecycleService):
         return self._states[marketplace_id]
 
     def _handle_transport_failure(
-        self, state: MarketplaceDeliveryState, now: float
+        self, state: MarketplaceDeliveryState, now: float, immediate: bool = False
     ) -> None:
         """Handle a transport failure — backoff after repeated failures.
 
         First TRANSPORT_MAX_FAILURES attempts retry every CHECK_INTERVAL (no backoff).
         After that, exponential backoff up to TRANSPORT_MAX_INTERVAL.
+
+        With immediate=True (rate limited: the server asked us to slow
+        down), the grace period is skipped and backoff starts on the first
+        failure, escalating with each consecutive one.
         """
         state.consecutive_failures += 1
-        if state.consecutive_failures >= self.TRANSPORT_MAX_FAILURES:
+        effective_failures = state.consecutive_failures
+        if immediate:
+            effective_failures += self.TRANSPORT_MAX_FAILURES - 1
+        if effective_failures >= self.TRANSPORT_MAX_FAILURES:
             backoff = min(
                 self._check_interval
                 * (
                     self.TRANSPORT_BACKOFF_FACTOR
-                    ** (state.consecutive_failures - self.TRANSPORT_MAX_FAILURES)
+                    ** (effective_failures - self.TRANSPORT_MAX_FAILURES)
                 ),
                 self.TRANSPORT_MAX_INTERVAL,
             )

--- a/backend/syft_space/components/marketplaces/handlers.py
+++ b/backend/syft_space/components/marketplaces/handlers.py
@@ -165,7 +165,12 @@ class MarketplaceHandler:
         """
         async with SyftHubClient(str(request.url)) as syfthub_client:
             try:
-                await syfthub_client.login(request.username, request.password)
+                # use_cache=False: this login validates user-supplied
+                # credentials before they are persisted — a cached session
+                # for the same account must not mask a wrong password.
+                await syfthub_client.login(
+                    request.username, request.password, use_cache=False
+                )
                 user_profile = await syfthub_client.profile()
                 await self._sync_public_url(syfthub_client)
             except SyftHubError as e:

--- a/backend/syft_space/components/model_types/openai/openai_type.py
+++ b/backend/syft_space/components/model_types/openai/openai_type.py
@@ -3,6 +3,8 @@
 from collections.abc import Awaitable, Callable
 from typing import Any
 
+from loguru import logger
+
 from syft_space.components.model_types.interfaces import (
     BaseModelType,
     ChatContext,
@@ -24,6 +26,12 @@ try:
 except ImportError:
     enabled = False
 
+# Retries for transient failures (429, 5xx, timeouts); the client's built-in
+# backoff honors the server's Retry-After header.
+MAX_RETRIES = 3
+# Per-request timeout in seconds.
+REQUEST_TIMEOUT_SECONDS = 600.0
+
 
 class OpenAIModelType(BaseModelType):
     """OpenAI model type for interacting with OpenAI's API.
@@ -44,12 +52,14 @@ class OpenAIModelType(BaseModelType):
         """
         self.config = config
         if enabled:
-            api_key = config.get("api_key", "")
-            base_url = config.get("base_url")
-            if base_url:
-                self.client = AsyncOpenAI(api_key=api_key, base_url=base_url)
-            else:
-                self.client = AsyncOpenAI(api_key=api_key)
+            client_kwargs: dict[str, Any] = {
+                "api_key": config.get("api_key", ""),
+                "max_retries": MAX_RETRIES,
+                "timeout": REQUEST_TIMEOUT_SECONDS,
+            }
+            if config.get("base_url"):
+                client_kwargs["base_url"] = config["base_url"]
+            self.client = AsyncOpenAI(**client_kwargs)
 
     @classmethod
     def name(cls) -> str:
@@ -175,6 +185,22 @@ class OpenAIModelType(BaseModelType):
 
         # Call OpenAI API
         response = await self.client.chat.completions.create(**completion_params)
+
+        # Upstream gateways occasionally return an empty completion (all-None
+        # payload) on transient failures instead of an HTTP error.
+        if not response.choices:
+            logger.info(
+                f"Model {model} returned a completion with no choices "
+                f"(response_id={response.id}), returning empty response"
+            )
+            return ChatResult(
+                id=response.id or "",
+                model=response.model or model,
+                messages=[],
+                finish_reason="error",
+                usage=TokenUsage(prompt_tokens=0, completion_tokens=0, total_tokens=0),
+                metadata={"empty_response": True},
+            )
 
         # Extract the first choice (OpenAI returns a list)
         choice = response.choices[0]

--- a/backend/syft_space/components/shared/syfthub_client.py
+++ b/backend/syft_space/components/shared/syfthub_client.py
@@ -104,6 +104,12 @@ class FailedDependencyError(SyftHubError):
     pass
 
 
+class RateLimitError(SyftHubError):
+    """Rate limited by SyftHub (429) - callers should back off, not retry."""
+
+    pass
+
+
 class ServerError(SyftHubError):
     """Server-side error (5xx) - covers 500, 502, 503, 504, etc."""
 
@@ -311,6 +317,8 @@ def _raise_for_status(response: httpx.Response) -> None:
         raise FailedDependencyError(
             parsed.message, status_code=status, code=parsed.code
         )
+    elif status == 429:
+        raise RateLimitError(parsed.message, status_code=status, code=parsed.code)
     elif status >= 500:
         raise ServerError(parsed.message, status_code=status, code=parsed.code)
     else:

--- a/backend/syft_space/components/shared/syfthub_client.py
+++ b/backend/syft_space/components/shared/syfthub_client.py
@@ -1,10 +1,15 @@
 """SyftHub marketplace API client using httpx."""
 
 import asyncio
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Awaitable, Callable
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, TypeVar
+
+import httpx
+from fastapi import HTTPException
+from loguru import logger
+from pydantic import BaseModel, EmailStr, Field, HttpUrl
 
 
 class _Unset(Enum):
@@ -14,11 +19,6 @@ class _Unset(Enum):
 
 
 UNSET = _Unset.UNSET
-
-import httpx
-from fastapi import HTTPException
-from loguru import logger
-from pydantic import BaseModel, EmailStr, Field, HttpUrl
 
 # =============================================================================
 # Exceptions
@@ -342,27 +342,75 @@ def _handle_response_raw(response: httpx.Response) -> dict[str, Any]:
 # =============================================================================
 
 
+class TokenCache:
+    """Process-wide SyftHub session store, keyed by (base_url, username).
+
+    Lets short-lived SyftHubClient instances (heartbeats, per-request auth)
+    reuse sessions instead of hitting /auth/login — the most expensive and
+    rate-limited endpoint — on every instantiation.
+    """
+
+    def __init__(self) -> None:
+        self._tokens: dict[tuple[str, str], TokenResponse] = {}
+
+    def get(self, base_url: str, username: str) -> TokenResponse | None:
+        """Return the cached session for this identity, if any."""
+        return self._tokens.get((base_url, username))
+
+    def put(self, base_url: str, username: str, tokens: TokenResponse) -> None:
+        """Store (or replace) the session for this identity."""
+        self._tokens[(base_url, username)] = tokens
+
+    def evict(self, base_url: str, username: str) -> None:
+        """Drop the session for this identity so it can't be reused."""
+        self._tokens.pop((base_url, username), None)
+
+    def clear(self) -> None:
+        """Drop all cached sessions (forces fresh logins)."""
+        self._tokens.clear()
+
+
+# Default cache shared by all clients in the process.
+_default_token_cache = TokenCache()
+
+
 class AsyncRefreshTokenAuth(httpx.Auth):
     """Auto-refresh auth that handles 401s by refreshing the access token."""
 
     requires_response_body = True
 
     def __init__(
-        self, auth_client: httpx.AsyncClient, access_token: str, refresh_token: str
+        self,
+        auth_client: httpx.AsyncClient,
+        access_token: str,
+        refresh_token: str,
+        on_tokens_updated: Callable[[TokenResponse], None] | None = None,
+        relogin: Callable[[], Awaitable[TokenResponse]] | None = None,
     ):
         self.auth_client = auth_client
         self.access_token = access_token
         self.refresh_token = refresh_token
+        self._on_tokens_updated = on_tokens_updated
+        self._relogin = relogin
         self._lock = asyncio.Lock()
 
     async def _refresh(self) -> None:
-        response = await self.auth_client.post(
-            "/api/v1/auth/refresh",
-            json={"refresh_token": self.refresh_token},
-        )
-        tokens = _handle_response(response, TokenResponse)
+        try:
+            response = await self.auth_client.post(
+                "/api/v1/auth/refresh",
+                json={"refresh_token": self.refresh_token},
+            )
+            tokens = _handle_response(response, TokenResponse)
+        except SyftHubError:
+            # Refresh token rejected (e.g. expired cached session) — fall
+            # back to a full password login when credentials are available.
+            if self._relogin is None:
+                raise
+            tokens = await self._relogin()
         self.access_token = tokens.access_token
         self.refresh_token = tokens.refresh_token
+        if self._on_tokens_updated is not None:
+            self._on_tokens_updated(tokens)
 
     async def async_auth_flow(
         self, request: httpx.Request
@@ -387,15 +435,25 @@ class SyftHubClient:
     # Default timeout for HTTP requests (10 seconds)
     DEFAULT_TIMEOUT = 10.0
 
-    def __init__(self, base_url: str, timeout: float | None = None):
+    def __init__(
+        self,
+        base_url: str,
+        timeout: float | None = None,
+        token_cache: TokenCache | None = None,
+    ):
         """Initialize SyftHub client.
 
         Args:
             base_url: Base URL for the SyftHub instance (str)
             timeout: Request timeout in seconds (default: 10.0)
+            token_cache: Session cache consulted by login(). Defaults to the
+                process-wide cache shared by all clients.
         """
         # Normalize URL (remove trailing slash)
         self.base_url = base_url.rstrip("/")
+        self._token_cache = (
+            token_cache if token_cache is not None else _default_token_cache
+        )
         self._timeout = httpx.Timeout(timeout or self.DEFAULT_TIMEOUT)
         self._auth_client = httpx.AsyncClient(
             base_url=self.base_url, timeout=self._timeout
@@ -482,33 +540,95 @@ class SyftHubClient:
         Used when a sibling endpoint (e.g. /auth/register/verify-otp) already
         issued tokens — skips the extra /auth/login round-trip.
         """
-        self._tokens = TokenResponse(
-            access_token=access_token, refresh_token=refresh_token
+        self._install_auth(
+            TokenResponse(access_token=access_token, refresh_token=refresh_token)
         )
+
+    def _install_auth(
+        self,
+        tokens: TokenResponse,
+        on_tokens_updated: Callable[[TokenResponse], None] | None = None,
+        relogin: Callable[[], Awaitable[TokenResponse]] | None = None,
+    ) -> None:
+        """Build the authenticated client around the given tokens."""
+        self._tokens = tokens
         auth = AsyncRefreshTokenAuth(
             auth_client=self._auth_client,
-            access_token=access_token,
-            refresh_token=refresh_token,
+            access_token=tokens.access_token,
+            refresh_token=tokens.refresh_token,
+            on_tokens_updated=on_tokens_updated,
+            relogin=relogin,
         )
         self._client = httpx.AsyncClient(
             base_url=self.base_url, auth=auth, timeout=self._timeout
         )
 
-    async def login(self, username: str, password: str) -> TokenResponse:
+    async def _password_login(self, username: str, password: str) -> TokenResponse:
+        """POST credentials to /auth/login and return fresh tokens."""
+        response = await self._auth_client.post(
+            "/api/v1/auth/login",
+            data={"username": username, "password": password},
+        )
+        return _handle_response(response, TokenResponse)
+
+    async def _relogin(self, username: str, password: str) -> TokenResponse:
+        """Full password login used as refresh fallback.
+
+        Evicts the cached session on failure so a dead token can't be
+        served to subsequent clients.
+        """
+        try:
+            return await self._password_login(username, password)
+        except SyftHubError:
+            self._token_cache.evict(self.base_url, username)
+            raise
+
+    async def login(
+        self, username: str, password: str, use_cache: bool = True
+    ) -> TokenResponse:
         """
         Login and setup authenticated client.
+
+        Reuses the token cache's session for this (base_url, username)
+        when available, skipping the /auth/login round-trip. An expired
+        cached session is refreshed transparently on first 401; if the
+        refresh token is also rejected, a full password login runs instead.
+
+        Args:
+            username: SyftHub login email
+            password: SyftHub password
+            use_cache: Reuse/populate the token cache. Pass False to force
+                a credential-validating login.
 
         Raises:
             AuthenticationError: Invalid credentials
             ValidationError: Invalid request data
             ServerError: Server-side error
         """
-        response = await self._auth_client.post(
-            "/api/v1/auth/login",
-            data={"username": username, "password": password},
-        )
-        tokens = _handle_response(response, TokenResponse)
-        self.authenticate_with_tokens(tokens.access_token, tokens.refresh_token)
+
+        def _cache_tokens(tokens: TokenResponse) -> None:
+            self._tokens = tokens
+            self._token_cache.put(self.base_url, username, tokens)
+
+        async def _relogin_fallback() -> TokenResponse:
+            return await self._relogin(username, password)
+
+        if use_cache:
+            cached = self._token_cache.get(self.base_url, username)
+            if cached is not None:
+                self._install_auth(
+                    cached, on_tokens_updated=_cache_tokens, relogin=_relogin_fallback
+                )
+                return cached
+
+        tokens = await self._password_login(username, password)
+        if use_cache:
+            self._token_cache.put(self.base_url, username, tokens)
+            self._install_auth(
+                tokens, on_tokens_updated=_cache_tokens, relogin=_relogin_fallback
+            )
+        else:
+            self._install_auth(tokens)
         return tokens
 
     async def accounting_credentials(self) -> AccountingResponse:

--- a/backend/syft_space/main.py
+++ b/backend/syft_space/main.py
@@ -546,6 +546,8 @@ _OUTCOME_TO_STATUS = {
     QueryOutcome.NOT_PUBLISHED: QueryEventStatus.NOT_PUBLISHED,
     QueryOutcome.PAYMENT_REQUIRED: QueryEventStatus.PAYMENT_REQUIRED,
     QueryOutcome.POLICY_VIOLATION: QueryEventStatus.POLICY_VIOLATION,
+    QueryOutcome.ACCESS_DENIED: QueryEventStatus.ACCESS_DENIED,
+    QueryOutcome.RATE_LIMITED: QueryEventStatus.RATE_LIMITED,
     QueryOutcome.INTERNAL_ERROR: QueryEventStatus.INTERNAL_ERROR,
 }
 _pending_event_tasks: set[asyncio.Task] = set()
@@ -592,7 +594,9 @@ async def report_query_event(event: QueryOutcomeEvent) -> None:
             endpoint_slug=event.endpoint_slug,
             dataset_id=event.dataset_id,
             user_email=event.user_email,
-            status=_OUTCOME_TO_STATUS[event.outcome].value,
+            status=_OUTCOME_TO_STATUS.get(
+                event.outcome, QueryEventStatus.INTERNAL_ERROR
+            ).value,
             query_text=query_text,
             cost_lines=cost_lines,
         )

--- a/backend/tests/components/endpoints/test_endpoint_heartbeat_backoff.py
+++ b/backend/tests/components/endpoints/test_endpoint_heartbeat_backoff.py
@@ -1,0 +1,130 @@
+"""Tests for endpoint heartbeat transport backoff, especially 429 handling.
+
+Rate-limited deliveries (429) must back off immediately instead of
+retrying every cycle; other transport failures keep the grace period of
+TRANSPORT_MAX_FAILURES fast retries.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+from syft_space.components.endpoints import endpoint_heartbeat_manager as hb_module
+from syft_space.components.endpoints.endpoint_heartbeat_manager import (
+    EndpointHeartbeatManager,
+    MarketplaceDeliveryState,
+)
+from syft_space.components.shared.syfthub_client import RateLimitError
+
+NOW = 1000.0
+
+
+def make_manager() -> EndpointHeartbeatManager:
+    return EndpointHeartbeatManager(
+        health_checker=SimpleNamespace(),
+        marketplace_repository=SimpleNamespace(),
+        settings_repository=SimpleNamespace(),
+    )
+
+
+def make_state() -> MarketplaceDeliveryState:
+    return MarketplaceDeliveryState(marketplace_id=uuid4())
+
+
+def test_first_rate_limit_backs_off_immediately():
+    manager = make_manager()
+    state = make_state()
+
+    manager._handle_transport_failure(state, NOW, immediate=True)
+
+    assert state.consecutive_failures == 1
+    assert state.next_delivery_at == NOW + manager.CHECK_INTERVAL
+
+
+def test_consecutive_rate_limits_escalate_and_cap():
+    manager = make_manager()
+    state = make_state()
+
+    backoffs = []
+    for _ in range(6):
+        manager._handle_transport_failure(state, NOW, immediate=True)
+        backoffs.append(state.next_delivery_at - NOW)
+
+    assert backoffs == [30.0, 60.0, 120.0, 240.0, 300.0, 300.0]
+
+
+def test_transient_failures_keep_grace_period():
+    manager = make_manager()
+    state = make_state()
+
+    for _ in range(manager.TRANSPORT_MAX_FAILURES - 1):
+        manager._handle_transport_failure(state, NOW)
+    assert state.next_delivery_at == 0.0  # still retrying every cycle
+
+    manager._handle_transport_failure(state, NOW)
+    assert state.next_delivery_at == NOW + manager.CHECK_INTERVAL
+
+
+def test_rate_limit_after_transient_failures_escalates_from_streak():
+    manager = make_manager()
+    state = make_state()
+
+    manager._handle_transport_failure(state, NOW)  # transient, no backoff
+    manager._handle_transport_failure(state, NOW, immediate=True)
+
+    assert state.consecutive_failures == 2
+    assert state.next_delivery_at == NOW + 2 * manager.CHECK_INTERVAL
+
+
+class _RateLimitedClient:
+    """SyftHubClient stand-in whose login is always rate limited."""
+
+    instantiations = 0
+
+    def __init__(self, *args, **kwargs):
+        type(self).instantiations += 1
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def login(self, *args, **kwargs):
+        raise RateLimitError("Too many requests", status_code=429)
+
+
+def make_marketplace() -> SimpleNamespace:
+    return SimpleNamespace(
+        id=uuid4(),
+        name="Test Hub",
+        url="https://hub.test",
+        email="space@test.org",
+        password="pw",
+    )
+
+
+async def test_rate_limited_delivery_backs_off_and_skips_next_attempt(monkeypatch):
+    monkeypatch.setattr(hb_module, "SyftHubClient", _RateLimitedClient)
+    _RateLimitedClient.instantiations = 0
+
+    manager = make_manager()
+    marketplace = make_marketplace()
+    health = [{"slug": "ep", "status": "online", "checked_at": "now"}]
+
+    await manager._send_endpoint_heartbeat_to_marketplace(
+        marketplace, "https://space.test", health
+    )
+
+    state = manager._states[marketplace.id]
+    assert state.consecutive_failures == 1
+    assert state.next_delivery_at > 0
+    assert _RateLimitedClient.instantiations == 1
+
+    # Second cycle arrives while still in backoff: no request is attempted
+    await manager._send_endpoint_heartbeat_to_marketplace(
+        marketplace, "https://space.test", health
+    )
+    assert _RateLimitedClient.instantiations == 1
+    assert state.consecutive_failures == 1

--- a/backend/tests/components/shared/test_syfthub_token_cache.py
+++ b/backend/tests/components/shared/test_syfthub_token_cache.py
@@ -1,0 +1,185 @@
+"""Tests for SyftHubClient session caching via TokenCache.
+
+The cache exists so short-lived clients (heartbeats, per-request auth)
+reuse sessions instead of hitting /auth/login on every instantiation.
+Tests inject isolated TokenCache instances; one test covers the shared
+process-wide default.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+import syft_space.components.shared.syfthub_client as syfthub_client_module
+from syft_space.components.shared.syfthub_client import (
+    AsyncRefreshTokenAuth,
+    AuthenticationError,
+    SyftHubClient,
+    TokenCache,
+    TokenResponse,
+)
+
+HUB_URL = "https://hub.test"
+USER = "user@test.org"
+TOKENS = TokenResponse(access_token="access-1", refresh_token="refresh-1")
+
+
+@pytest.fixture
+def login_spy(monkeypatch):
+    """Replace the network login with a counting stub."""
+    calls: list[tuple[str, str]] = []
+
+    async def fake_password_login(self, username: str, password: str):
+        calls.append((username, password))
+        return TOKENS
+
+    monkeypatch.setattr(SyftHubClient, "_password_login", fake_password_login)
+    return calls
+
+
+async def test_first_login_hits_network_and_caches(login_spy):
+    cache = TokenCache()
+    async with SyftHubClient(HUB_URL, token_cache=cache) as client:
+        tokens = await client.login(USER, "pw")
+
+    assert tokens == TOKENS
+    assert login_spy == [(USER, "pw")]
+    assert cache.get(HUB_URL, USER) == TOKENS
+
+
+async def test_second_client_reuses_cached_session(login_spy):
+    cache = TokenCache()
+    async with SyftHubClient(HUB_URL, token_cache=cache) as first:
+        await first.login(USER, "pw")
+    async with SyftHubClient(HUB_URL, token_cache=cache) as second:
+        tokens = await second.login(USER, "pw")
+
+    assert len(login_spy) == 1
+    assert tokens == TOKENS
+    assert second.is_authenticated
+
+
+async def test_default_cache_is_shared_across_clients(login_spy, monkeypatch):
+    monkeypatch.setattr(syfthub_client_module, "_default_token_cache", TokenCache())
+    async with SyftHubClient(HUB_URL) as first:
+        await first.login(USER, "pw")
+    async with SyftHubClient(HUB_URL) as second:
+        await second.login(USER, "pw")
+
+    assert len(login_spy) == 1
+
+
+async def test_cache_is_scoped_per_url_and_username(login_spy):
+    cache = TokenCache()
+    async with SyftHubClient(HUB_URL, token_cache=cache) as client:
+        await client.login(USER, "pw")
+    async with SyftHubClient(HUB_URL, token_cache=cache) as client:
+        await client.login("other@test.org", "pw")
+    async with SyftHubClient("https://other-hub.test", token_cache=cache) as client:
+        await client.login(USER, "pw")
+
+    assert len(login_spy) == 3
+
+
+async def test_use_cache_false_always_validates_credentials(login_spy):
+    cache = TokenCache()
+    async with SyftHubClient(HUB_URL, token_cache=cache) as client:
+        await client.login(USER, "pw")
+    async with SyftHubClient(HUB_URL, token_cache=cache) as client:
+        await client.login(USER, "pw", use_cache=False)
+
+    assert len(login_spy) == 2
+
+    # Bypassing login must not populate the cache either
+    fresh_cache = TokenCache()
+    async with SyftHubClient(HUB_URL, token_cache=fresh_cache) as client:
+        await client.login(USER, "pw", use_cache=False)
+    assert fresh_cache.get(HUB_URL, USER) is None
+
+
+async def test_authenticate_with_tokens_does_not_touch_cache():
+    cache = TokenCache()
+    async with SyftHubClient(HUB_URL, token_cache=cache) as client:
+        client.authenticate_with_tokens("access-x", "refresh-x")
+
+    assert client.is_authenticated
+    assert cache.get(HUB_URL, USER) is None
+
+
+async def test_relogin_failure_evicts_cached_session(monkeypatch):
+    cache = TokenCache()
+    cache.put(HUB_URL, USER, TOKENS)
+
+    async def failing_login(self, username: str, password: str):
+        raise AuthenticationError("Invalid credentials", status_code=401)
+
+    monkeypatch.setattr(SyftHubClient, "_password_login", failing_login)
+
+    async with SyftHubClient(HUB_URL, token_cache=cache) as client:
+        with pytest.raises(AuthenticationError):
+            await client._relogin(USER, "pw")
+
+    assert cache.get(HUB_URL, USER) is None
+
+
+class _StubAuthClient:
+    """Fake httpx client returning canned responses for /auth/refresh."""
+
+    def __init__(self, response: httpx.Response):
+        self._response = response
+        self.calls = 0
+
+    async def post(self, *args, **kwargs) -> httpx.Response:
+        self.calls += 1
+        return self._response
+
+
+async def test_refresh_success_updates_tokens_and_cache():
+    fresh = {"access_token": "access-2", "refresh_token": "refresh-2"}
+    stub = _StubAuthClient(httpx.Response(200, json=fresh))
+    updated: list[TokenResponse] = []
+
+    auth = AsyncRefreshTokenAuth(
+        auth_client=stub,  # type: ignore[arg-type]
+        access_token="access-1",
+        refresh_token="refresh-1",
+        on_tokens_updated=updated.append,
+    )
+    await auth._refresh()
+
+    assert auth.access_token == "access-2"
+    assert auth.refresh_token == "refresh-2"
+    assert updated and updated[0].access_token == "access-2"
+
+
+async def test_refresh_falls_back_to_relogin_when_refresh_rejected():
+    stub = _StubAuthClient(httpx.Response(401, json={"detail": "expired"}))
+    fresh = TokenResponse(access_token="access-3", refresh_token="refresh-3")
+    updated: list[TokenResponse] = []
+
+    async def relogin() -> TokenResponse:
+        return fresh
+
+    auth = AsyncRefreshTokenAuth(
+        auth_client=stub,  # type: ignore[arg-type]
+        access_token="access-1",
+        refresh_token="refresh-1",
+        on_tokens_updated=updated.append,
+        relogin=relogin,
+    )
+    await auth._refresh()
+
+    assert auth.access_token == "access-3"
+    assert updated == [fresh]
+
+
+async def test_refresh_without_relogin_propagates_error():
+    stub = _StubAuthClient(httpx.Response(401, json={"detail": "expired"}))
+    auth = AsyncRefreshTokenAuth(
+        auth_client=stub,  # type: ignore[arg-type]
+        access_token="access-1",
+        refresh_token="refresh-1",
+    )
+    with pytest.raises(AuthenticationError):
+        await auth._refresh()


### PR DESCRIPTION
This pull request introduces several important improvements to error handling, rate limiting, and session management for interactions with external services such as SyftHub and OpenAI. The main themes are: enhanced rate limit awareness and backoff strategies, improved session caching for SyftHub authentication, and more robust handling of edge cases in OpenAI API responses.

**Key changes include:**

### Rate Limiting and Error Handling

* Added explicit handling for rate limiting (HTTP 429) in the SyftHub client by introducing a new `RateLimitError` exception, updating the `_raise_for_status` function, and ensuring that the heartbeat manager backs off immediately when rate limited. This prevents repeated requests during rate limiting events and helps avoid further throttling. [[1]](diffhunk://#diff-fd4cac69b4f525f26ec47c04af908006e5722f30a8b55b3e38764c3318d8c1c5R107-R112) [[2]](diffhunk://#diff-fd4cac69b4f525f26ec47c04af908006e5722f30a8b55b3e38764c3318d8c1c5R320-R321) [[3]](diffhunk://#diff-56aea79b818031ab0004e189ad16b925ae6a5649f21d23f48564ddc1e491b63bR324-R330) [[4]](diffhunk://#diff-a071ff1eb9ab102cc5d5b7c3df28a6285371f382175620fae7cece5adef6113dR20-R21) [[5]](diffhunk://#diff-fa0d477f91a4e3530b4876cff3a71f75b2e03828add9f2d3336a2e1e9ddf8446R549-R550)
* The endpoint heartbeat manager now adds random jitter to its check interval to desynchronize co-located instances, reducing the chance of simultaneous requests that could trigger rate limiting. [[1]](diffhunk://#diff-56aea79b818031ab0004e189ad16b925ae6a5649f21d23f48564ddc1e491b63bR59) [[2]](diffhunk://#diff-56aea79b818031ab0004e189ad16b925ae6a5649f21d23f48564ddc1e491b63bL171-R177) [[3]](diffhunk://#diff-56aea79b818031ab0004e189ad16b925ae6a5649f21d23f48564ddc1e491b63bL183-R204)

### Session and Token Management

* Introduced a process-wide token cache (`TokenCache`) in the SyftHub client, allowing short-lived client instances to reuse authentication sessions and avoid unnecessary logins to the most rate-limited endpoints. The login method now supports bypassing the cache for explicit credential validation. [[1]](diffhunk://#diff-fd4cac69b4f525f26ec47c04af908006e5722f30a8b55b3e38764c3318d8c1c5R353-R421) [[2]](diffhunk://#diff-fd4cac69b4f525f26ec47c04af908006e5722f30a8b55b3e38764c3318d8c1c5L390-R464) [[3]](diffhunk://#diff-fd4cac69b4f525f26ec47c04af908006e5722f30a8b55b3e38764c3318d8c1c5L485-R639) [[4]](diffhunk://#diff-7f8217e030e87974a05bf0d841fc588568c16de2f768a072ee74e21c34e7f4d1L168-R173)
* Improved the refresh token flow in `AsyncRefreshTokenAuth` to fall back to a full password login if the refresh token is rejected, and to evict dead sessions from the cache to prevent subsequent failures.

### OpenAI API Robustness

* Updated the OpenAI model type to configure the client with a higher per-request timeout and a maximum retry count, improving resilience to transient failures. The code also now gracefully handles empty completions (where the API returns no choices) by returning a structured error response, instead of failing silently or raising an exception. [[1]](diffhunk://#diff-de6ca2fc3ced57a21776d015b60256e49864f6c7fe43a1996eb7bfa03f5199bcR29-R34) [[2]](diffhunk://#diff-de6ca2fc3ced57a21776d015b60256e49864f6c7fe43a1996eb7bfa03f5199bcL47-R62) [[3]](diffhunk://#diff-de6ca2fc3ced57a21776d015b60256e49864f6c7fe43a1996eb7bfa03f5199bcR189-R204)

### Minor Improvements

* Updated imports and cleaned up unused imports in several files for clarity and maintainability. [[1]](diffhunk://#diff-56aea79b818031ab0004e189ad16b925ae6a5649f21d23f48564ddc1e491b63bR6) [[2]](diffhunk://#diff-56aea79b818031ab0004e189ad16b925ae6a5649f21d23f48564ddc1e491b63bL14-R19) [[3]](diffhunk://#diff-fd4cac69b4f525f26ec47c04af908006e5722f30a8b55b3e38764c3318d8c1c5L4-R13) [[4]](diffhunk://#diff-fd4cac69b4f525f26ec47c04af908006e5722f30a8b55b3e38764c3318d8c1c5L18-L22)
* Added new status codes to `QueryEventStatus` to reflect access denial and rate limiting in the analytics entities. [[1]](diffhunk://#diff-a071ff1eb9ab102cc5d5b7c3df28a6285371f382175620fae7cece5adef6113dR20-R21) [[2]](diffhunk://#diff-fa0d477f91a4e3530b4876cff3a71f75b2e03828add9f2d3336a2e1e9ddf8446R549-R550)

These changes collectively make the system more robust against external service failures, improve user experience during rate limiting events, and reduce unnecessary authentication overhead.