### PR TITLE
Add managed cluster credits wallet and frontend integration

### DIFF
--- a/backend/syft_space/components/endpoints/policy_charging.py
+++ b/backend/syft_space/components/endpoints/policy_charging.py
@@ -9,6 +9,8 @@ retrieve the charger they need by mechanism.
 
 from uuid import UUID
 
+from syft_space.components.payments.cluster.charger import ClusterCreditsCharger
+from syft_space.components.payments.cluster.credits_client import ClusterCreditsClient
 from syft_space.components.payments.gateway.balance_charger import (
     WalletBalanceCharger,
 )
@@ -51,6 +53,19 @@ def build_payment_chargers(
                 secret_key=wallet.configuration.get("mpp_secret_key", ""),
                 realm=endpoint_slug,
                 x_payment=x_payment,
+            )
+        elif wallet.wallet_type == "cluster" and balance_service is not None:
+            prepaid = ClusterCreditsCharger(
+                client=ClusterCreditsClient(
+                    base_url=wallet.configuration.get("credits_url", ""),
+                    service_token=wallet.configuration.get("service_token", ""),
+                ),
+                balance_service=balance_service,
+                wallet_id=wallet.id,
+                currency=wallet.currency,
+                tenant_id=tenant_id,
+                endpoint_id=endpoint_id,
+                endpoint_slug=endpoint_slug,
             )
         elif (
             wallet.wallet_type in PREPAID_BALANCE_WALLET_TYPES

--- a/backend/syft_space/components/payments/cluster/charger.py
+++ b/backend/syft_space/components/payments/cluster/charger.py
@@ -1,0 +1,104 @@
+"""Charger for the managed cluster wallet.
+
+Implements the PrepaidBalanceCharger Protocol — the same shape policies
+already use for xendit/stripe — but the authoritative balance lives at
+the cluster's credits service. After every confirmed remote call the
+charger journals a record-only LedgerEntry locally (spend history +
+payout cross-check); the journal is never read for money decisions.
+"""
+
+import logging
+from uuid import UUID, uuid4
+
+from syft_space.components.payments.cluster.credits_client import (
+    ClusterCreditsClient,
+    InsufficientCreditsError,
+)
+from syft_space.components.payments.gateway.balance_service import BalanceService
+from syft_space.components.policy_types.interfaces import BalanceShortfallError
+
+logger = logging.getLogger(__name__)
+
+
+class ClusterCreditsCharger:
+    """Per-request charger bound to one cluster wallet and endpoint."""
+
+    def __init__(
+        self,
+        *,
+        client: ClusterCreditsClient,
+        balance_service: BalanceService,
+        wallet_id: UUID,
+        currency: str,
+        tenant_id: UUID,
+        endpoint_id: UUID,
+        endpoint_slug: str,
+    ) -> None:
+        self._client = client
+        self._balance_service = balance_service
+        self._wallet_id = wallet_id
+        self._currency = currency
+        self._tenant_id = tenant_id
+        self._endpoint_id = endpoint_id
+        self._endpoint_slug = endpoint_slug
+
+    @property
+    def currency(self) -> str:
+        return self._currency
+
+    @property
+    def wallet_type(self) -> str:
+        return "cluster"
+
+    async def get_balance(self, user_email: str) -> float:
+        return await self._client.get_balance(user_email)
+
+    async def reserve(
+        self,
+        *,
+        user_email: str,
+        amount: float,
+        charge_unit: str,
+        charge_quantity: int,
+    ) -> UUID:
+        transaction_id = uuid4()
+        try:
+            await self._client.debit(
+                transaction_id=transaction_id,
+                user_email=user_email,
+                amount=amount,
+                endpoint=self._endpoint_slug,
+                charge_unit=charge_unit,
+                charge_quantity=charge_quantity,
+            )
+        except InsufficientCreditsError as exc:
+            raise BalanceShortfallError(
+                balance=exc.balance, required=amount, currency=self._currency
+            ) from exc
+
+        # Journal after the confirmed debit. A journal failure must not
+        # fail the query — the money already moved; the cluster ledger
+        # stays authoritative and reconcilable by transaction_id.
+        try:
+            await self._balance_service.record_external_debit(
+                wallet_id=self._wallet_id,
+                tenant_id=self._tenant_id,
+                user_email=user_email,
+                endpoint_id=self._endpoint_id,
+                transaction_id=transaction_id,
+                amount=amount,
+                currency=self._currency,
+                charge_unit=charge_unit,
+                charge_quantity=charge_quantity,
+            )
+        except Exception as e:
+            logger.warning(f"Journal write failed for debit {transaction_id}: {e}")
+
+        return transaction_id
+
+    async def cancel(self, transaction_id: UUID) -> None:
+        await self._client.refund(transaction_id)
+        try:
+            await self._balance_service.record_external_cancel(transaction_id)
+        except Exception as e:
+            logger.warning(f"Journal write failed for refund {transaction_id}: {e}")

--- a/backend/syft_space/components/payments/cluster/credits_client.py
+++ b/backend/syft_space/components/payments/cluster/credits_client.py
@@ -1,0 +1,126 @@
+"""HTTP client for the cluster's credits API.
+
+Transport only — debit / refund / balance against the cluster credits
+service, authenticated with the space's service token. Fail-closed by
+design: any transport failure raises, and the caller rejects the paid
+query. See cluster.md "Credits API contract".
+"""
+
+import logging
+from typing import Any
+from uuid import UUID
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# Short timeout — this sits on the paid-query hot path.
+_HTTP_TIMEOUT_SECONDS = 5.0
+
+
+class ClusterCreditsError(RuntimeError):
+    """Credits service unreachable or returned an unexpected response."""
+
+
+class InsufficientCreditsError(Exception):
+    """Debit rejected: the user's cluster balance can't cover the amount."""
+
+    def __init__(self, balance: float, required: float):
+        super().__init__(f"Balance {balance} below required {required}")
+        self.balance = balance
+        self.required = required
+
+
+class ClusterCreditsClient:
+    """Client for one cluster credits service, bound to one space token."""
+
+    def __init__(self, base_url: str, service_token: str):
+        self.base_url = base_url.rstrip("/")
+        self._service_token = service_token
+
+    def _build_http_client(self) -> httpx.AsyncClient:
+        return httpx.AsyncClient(
+            base_url=self.base_url,
+            timeout=_HTTP_TIMEOUT_SECONDS,
+            headers={"Authorization": f"Bearer {self._service_token}"},
+        )
+
+    async def debit(
+        self,
+        *,
+        transaction_id: UUID,
+        user_email: str,
+        amount: float,
+        endpoint: str,
+        charge_unit: str,
+        charge_quantity: int,
+    ) -> dict[str, Any]:
+        """Atomically debit the user's cluster balance.
+
+        ``transaction_id`` is the idempotency key — retries can't
+        double-debit. Raises InsufficientCreditsError on 402.
+        """
+        try:
+            async with self._build_http_client() as client:
+                response = await client.post(
+                    "/api/v1/credits/debit",
+                    json={
+                        "transaction_id": str(transaction_id),
+                        "user_email": user_email,
+                        "amount": amount,
+                        "endpoint": endpoint,
+                        "charge_unit": charge_unit,
+                        "charge_quantity": charge_quantity,
+                    },
+                )
+        except httpx.HTTPError as e:
+            raise ClusterCreditsError(
+                f"cluster credits service at {self.base_url} unavailable: {e}"
+            ) from e
+
+        if response.status_code == 402:
+            data = response.json()
+            raise InsufficientCreditsError(
+                balance=data.get("balance", 0.0),
+                required=data.get("required", amount),
+            )
+        if response.status_code != 200:
+            raise ClusterCreditsError(
+                f"credits debit failed ({response.status_code}): {response.text[:200]}"
+            )
+        return response.json()
+
+    async def refund(self, transaction_id: UUID) -> None:
+        """Reverse a debit (idempotent). 404 means nothing to reverse."""
+        try:
+            async with self._build_http_client() as client:
+                response = await client.post(
+                    "/api/v1/credits/refund",
+                    json={"transaction_id": str(transaction_id)},
+                )
+        except httpx.HTTPError as e:
+            raise ClusterCreditsError(
+                f"cluster credits service at {self.base_url} unavailable: {e}"
+            ) from e
+
+        if response.status_code == 404:
+            logger.warning(f"Refund for unknown transaction {transaction_id}")
+            return
+        if response.status_code != 200:
+            raise ClusterCreditsError(
+                f"credits refund failed ({response.status_code}): {response.text[:200]}"
+            )
+
+    async def get_balance(self, user_email: str) -> float:
+        """Return the user's spendable cluster balance."""
+        try:
+            async with self._build_http_client() as client:
+                response = await client.get(
+                    "/api/v1/credits/balance", params={"user_email": user_email}
+                )
+                response.raise_for_status()
+        except httpx.HTTPError as e:
+            raise ClusterCreditsError(
+                f"cluster credits service at {self.base_url} unavailable: {e}"
+            ) from e
+        return float(response.json()["balance"])

--- a/backend/syft_space/components/payments/gateway/balance_service.py
+++ b/backend/syft_space/components/payments/gateway/balance_service.py
@@ -151,6 +151,70 @@ class BalanceService:
 
             await ledger.commit()
 
+    async def record_external_debit(
+        self,
+        *,
+        wallet_id: UUID,
+        tenant_id: UUID,
+        user_email: str,
+        endpoint_id: UUID,
+        transaction_id: UUID,
+        amount: float,
+        currency: str,
+        charge_unit: str,
+        charge_quantity: int,
+    ) -> None:
+        """Journal a debit that settled on an external ledger (record-only).
+
+        For wallets whose authoritative balance lives outside this space
+        (cluster credits): writes the LedgerEntry so spend history is
+        queryable locally. Never touches UserBalance, and must never be
+        read for money decisions.
+        """
+        async with self._ledger() as ledger:
+            await ledger.entries.insert(
+                LedgerEntry(
+                    tenant_id=tenant_id,
+                    wallet_id=wallet_id,
+                    user_email=user_email,
+                    transaction_id=transaction_id,
+                    type=EntryType.DEBIT.value,
+                    endpoint_id=endpoint_id,
+                    amount=amount,
+                    currency=currency,
+                    charge_unit=charge_unit,
+                    charge_quantity=charge_quantity,
+                )
+            )
+            await ledger.commit()
+
+    async def record_external_cancel(self, transaction_id: UUID) -> None:
+        """Journal the reversal of an external debit (record-only).
+
+        Mirrors cancel() minus the balance restore. Missing debit (journal
+        write failed earlier) is a no-op — the cluster ledger stays
+        authoritative.
+        """
+        async with self._ledger() as ledger:
+            debit = await ledger.entries.get_debit_by_transaction_id(transaction_id)
+            if not debit or debit.wallet_id is None:
+                return
+            await ledger.entries.insert(
+                LedgerEntry(
+                    tenant_id=debit.tenant_id,
+                    wallet_id=debit.wallet_id,
+                    user_email=debit.user_email,
+                    transaction_id=transaction_id,
+                    type=EntryType.CANCELLED.value,
+                    endpoint_id=debit.endpoint_id,
+                    amount=debit.amount,
+                    currency=debit.currency,
+                    charge_unit=debit.charge_unit,
+                    charge_quantity=debit.charge_quantity,
+                )
+            )
+            await ledger.commit()
+
     async def get_balance(
         self, *, wallet_id: UUID, tenant_id: UUID, user_email: str
     ) -> float:

--- a/backend/syft_space/components/policy_types/__init__.py
+++ b/backend/syft_space/components/policy_types/__init__.py
@@ -16,6 +16,8 @@ def register_builtin_types(registry: "PolicyTypeRegistry") -> None:
     """
     # Import and register built-in policy types here as they're implemented
     from .access.access_type import EndpointAccessPolicy
+    from .cluster.cluster_per_document import ClusterPerDocumentPolicy
+    from .cluster.cluster_per_request import ClusterPerRequestPolicy
     from .mpp.mpp_per_document import MppPerDocumentPolicy
     from .mpp.mpp_per_request import MppPerRequestPolicy
     from .pii_filter.pii_filter_type import PiiFilterType
@@ -33,6 +35,8 @@ def register_builtin_types(registry: "PolicyTypeRegistry") -> None:
     registry.register_policy_type(XenditPerRequestPolicy)
     registry.register_policy_type(XenditPerDocumentPolicy)
     registry.register_policy_type(StripePerRequestPolicy)
+    registry.register_policy_type(ClusterPerRequestPolicy)
+    registry.register_policy_type(ClusterPerDocumentPolicy)
     registry.register_policy_type(StripePerDocumentPolicy)
 
 

--- a/backend/syft_space/components/policy_types/cluster/__init__.py
+++ b/backend/syft_space/components/policy_types/cluster/__init__.py
@@ -1,0 +1,1 @@
+"""Cluster credits payment policies (per-request, per-document)."""

--- a/backend/syft_space/components/policy_types/cluster/cluster_per_document.py
+++ b/backend/syft_space/components/policy_types/cluster/cluster_per_document.py
@@ -1,0 +1,22 @@
+"""Cluster credits per-document payment policy.
+
+All behavior is inherited from PrepaidBalancePerDocumentPolicy.
+"""
+
+from typing import ClassVar
+
+from syft_space.components.policy_types.prepaid.per_document import (
+    PrepaidBalancePerDocumentPolicy,
+)
+from syft_space.components.policy_types.prepaid.policy_config import (
+    PrepaidPerDocumentConfig,
+)
+
+
+class ClusterPerDocumentPolicy(PrepaidBalancePerDocumentPolicy):
+    PROVIDER_NAME: ClassVar[str] = "cluster"
+    NAME: ClassVar[str] = "cluster_per_document"
+    DESCRIPTION: ClassVar[str] = (
+        "Pay-per-document billed against the space's managed credits wallet"
+    )
+    CONFIG_CLS = PrepaidPerDocumentConfig

--- a/backend/syft_space/components/policy_types/cluster/cluster_per_request.py
+++ b/backend/syft_space/components/policy_types/cluster/cluster_per_request.py
@@ -1,0 +1,22 @@
+"""Cluster credits per-request payment policy.
+
+All behavior is inherited from PrepaidBalancePerRequestPolicy.
+"""
+
+from typing import ClassVar
+
+from syft_space.components.policy_types.prepaid.per_request import (
+    PrepaidBalancePerRequestPolicy,
+)
+from syft_space.components.policy_types.prepaid.policy_config import (
+    PrepaidPerRequestConfig,
+)
+
+
+class ClusterPerRequestPolicy(PrepaidBalancePerRequestPolicy):
+    PROVIDER_NAME: ClassVar[str] = "cluster"
+    NAME: ClassVar[str] = "cluster_per_request"
+    DESCRIPTION: ClassVar[str] = (
+        "Pay-per-request billed against the space's managed credits wallet"
+    )
+    CONFIG_CLS = PrepaidPerRequestConfig

--- a/backend/syft_space/components/wallets/cluster/config.py
+++ b/backend/syft_space/components/wallets/cluster/config.py
@@ -1,0 +1,19 @@
+"""Cluster wallet configuration.
+
+The managed credits wallet for spaces running inside a Syft Cluster.
+Balance and top-ups live at the cluster's credits service; the space
+holds only the connection details. Seeded from ``SYFT_CLUSTER_CREDITS_*``
+env at startup — never created through the wallet API.
+"""
+
+from pydantic import BaseModel, Field
+
+
+class ClusterWalletConfig(BaseModel):
+    """Connection details for the cluster credits service."""
+
+    credits_url: str = Field(..., description="Base URL of the cluster credits API")
+    service_token: str = Field(
+        ..., description="Per-space bearer token (minted at provisioning)"
+    )
+    currency: str = Field(default="USD", description="Credits currency code")

--- a/backend/syft_space/components/wallets/cluster/provider.py
+++ b/backend/syft_space/components/wallets/cluster/provider.py
@@ -1,0 +1,34 @@
+"""Cluster wallet provider.
+
+Exists for display/config plumbing only — cluster wallets are seeded
+from env at startup (see ``wallets/seed.py``), never created through
+the wallet API.
+"""
+
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel
+
+from syft_space.components.wallets.cluster.config import ClusterWalletConfig
+from syft_space.components.wallets.interfaces import SetupResult
+
+
+class ClusterWalletProvider:
+    """WalletProvider impl for the managed cluster wallet."""
+
+    @property
+    def config_class(self) -> type[BaseModel]:
+        return ClusterWalletConfig
+
+    async def setup_wallet(self, raw_credentials: dict[str, Any]) -> SetupResult:
+        raise ValueError(
+            "Cluster wallets are managed by the cluster and cannot be "
+            "created through the API"
+        )
+
+    def extract_display(
+        self, configuration: dict[str, Any], wallet_id: UUID
+    ) -> dict[str, Any]:
+        """Safe display info — never the service token."""
+        return {"managed_by": "Your cluster"}

--- a/backend/syft_space/components/wallets/handlers.py
+++ b/backend/syft_space/components/wallets/handlers.py
@@ -14,6 +14,7 @@ from syft_space.components.tenants.entities import Tenant
 from syft_space.components.wallets.interfaces import WalletProvider
 from syft_space.components.wallets.repository import WalletRepository
 from syft_space.components.wallets.schemas import WalletListItem, WalletResponse
+from syft_space.components.wallets.wallet_configs import WalletType
 
 
 class WalletHandler:
@@ -51,6 +52,11 @@ class WalletHandler:
 
     # --- Generic operations (all wallet types) ---
 
+    async def _has_managed_wallet(self, tenant_id) -> bool:
+        """True when a cluster-managed wallet exists for this tenant."""
+        wallets = await self.repository.get_all(tenant_id)
+        return any(w.wallet_type == WalletType.CLUSTER.value for w in wallets)
+
     async def list_wallets(self, tenant: Tenant) -> list[WalletListItem]:
         """List all wallets for a tenant."""
         wallets = await self.repository.get_all(tenant.id)
@@ -66,6 +72,7 @@ class WalletHandler:
                     country=w.country,
                     is_active=w.is_active,
                     display=display,
+                    managed=w.wallet_type == WalletType.CLUSTER.value,
                     created_at=w.created_at,
                 )
             )
@@ -87,6 +94,7 @@ class WalletHandler:
             country=wallet.country,
             is_active=wallet.is_active,
             display=display,
+            managed=wallet.wallet_type == WalletType.CLUSTER.value,
             created_at=wallet.created_at,
             updated_at=wallet.updated_at,
         )
@@ -103,6 +111,12 @@ class WalletHandler:
         wallet = await self.repository.get_by_id(wallet_id, tenant.id)
         if not wallet:
             raise HTTPException(status_code=404, detail="Wallet not found")
+
+        if wallet.wallet_type == WalletType.CLUSTER.value:
+            raise HTTPException(
+                status_code=403,
+                detail="This wallet is managed by the cluster and cannot be deleted",
+            )
 
         if not force and self.deletion_check is not None:
             error = await self.deletion_check(wallet_id, tenant.id)
@@ -128,7 +142,23 @@ class WalletHandler:
         The provider validates and enriches credentials, returning currency
         and (optionally) country alongside the configuration. The handler
         enforces (tenant, wallet_type, currency) uniqueness.
+
+        Blocked entirely while a cluster-managed wallet exists — members
+        of a Syft Cluster can only use the managed credits wallet.
         """
+        if wallet_type == WalletType.CLUSTER.value:
+            raise HTTPException(
+                status_code=403,
+                detail="Cluster wallets are seeded by the cluster, not created here",
+            )
+        if await self._has_managed_wallet(tenant.id):
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "Wallet creation is disabled — this space uses a "
+                    "managed credits wallet"
+                ),
+            )
         provider = self._get_provider(wallet_type)
 
         try:
@@ -182,6 +212,7 @@ class WalletHandler:
             country=wallet.country,
             is_active=wallet.is_active,
             display=display,
+            managed=wallet.wallet_type == WalletType.CLUSTER.value,
             created_at=wallet.created_at,
             updated_at=wallet.updated_at,
         )
@@ -206,6 +237,15 @@ class WalletHandler:
         if not wallet:
             raise HTTPException(status_code=404, detail="Wallet not found")
 
+        if wallet.wallet_type == WalletType.CLUSTER.value:
+            raise HTTPException(
+                status_code=403,
+                detail=(
+                    "This wallet is managed by the cluster — its config "
+                    "comes from the environment"
+                ),
+            )
+
         provider = self._get_provider(wallet.wallet_type)
         try:
             updated_config = provider.update_credentials(wallet.configuration, updates)
@@ -224,6 +264,7 @@ class WalletHandler:
             country=wallet.country,
             is_active=wallet.is_active,
             display=display,
+            managed=wallet.wallet_type == WalletType.CLUSTER.value,
             created_at=wallet.created_at,
             updated_at=wallet.updated_at,
         )

--- a/backend/syft_space/components/wallets/schemas.py
+++ b/backend/syft_space/components/wallets/schemas.py
@@ -26,6 +26,11 @@ class WalletResponse(BaseModel):
     display: dict[str, Any] = Field(
         default_factory=dict, description="Type-specific display info for frontend"
     )
+    managed: bool = Field(
+        default=False,
+        description="Wallet is managed externally (seeded from env); "
+        "creation/update/delete are disabled for it",
+    )
     created_at: datetime = Field(..., description="Creation timestamp")
     updated_at: datetime = Field(..., description="Last update timestamp")
 
@@ -44,6 +49,11 @@ class WalletListItem(BaseModel):
     is_active: bool = Field(..., description="Whether wallet is active")
     display: dict[str, Any] = Field(
         default_factory=dict, description="Type-specific display info"
+    )
+    managed: bool = Field(
+        default=False,
+        description="Wallet is managed externally (seeded from env); "
+        "creation/update/delete are disabled for it",
     )
     created_at: datetime = Field(..., description="Creation timestamp")
 

--- a/backend/syft_space/components/wallets/seed.py
+++ b/backend/syft_space/components/wallets/seed.py
@@ -17,7 +17,7 @@ from syft_space.config import app_settings
 
 logger = logging.getLogger(__name__)
 
-CLUSTER_WALLET_NAME = "Space Credits"
+CLUSTER_WALLET_NAME = "Cluster Shared Wallet"
 
 
 async def seed_cluster_wallet(repository: WalletRepository, tenant_id: UUID) -> None:

--- a/backend/syft_space/components/wallets/seed.py
+++ b/backend/syft_space/components/wallets/seed.py
@@ -1,0 +1,51 @@
+"""Seed the managed cluster wallet from env at startup.
+
+Spaces provisioned into a Syft Cluster get ``SYFT_CLUSTER_CREDITS_URL``
+and ``SYFT_CLUSTER_CREDITS_TOKEN`` in their Secret. This hook upserts the
+matching wallet so billing works without any UI action: create it when
+missing, refresh the stored config when the env changed (token rotation
+= Secret update + restart). No env → no-op (standalone spaces).
+"""
+
+import logging
+from uuid import UUID
+
+from syft_space.components.wallets.cluster.config import ClusterWalletConfig
+from syft_space.components.wallets.repository import WalletRepository
+from syft_space.components.wallets.wallet_configs import WalletType
+from syft_space.config import app_settings
+
+logger = logging.getLogger(__name__)
+
+CLUSTER_WALLET_NAME = "Space Credits"
+
+
+async def seed_cluster_wallet(repository: WalletRepository, tenant_id: UUID) -> None:
+    """Ensure the cluster wallet mirrors the ``SYFT_CLUSTER_CREDITS_*`` env."""
+    if not (app_settings.cluster_credits_url and app_settings.cluster_credits_token):
+        return
+
+    config = ClusterWalletConfig(
+        credits_url=str(app_settings.cluster_credits_url),
+        service_token=app_settings.cluster_credits_token,
+        currency=app_settings.cluster_credits_currency,
+    )
+
+    existing = await repository.get_by_type_and_currency(
+        WalletType.CLUSTER.value, config.currency, tenant_id
+    )
+    if existing is None:
+        wallet = await repository.create_wallet(
+            tenant_id=tenant_id,
+            wallet_type=WalletType.CLUSTER.value,
+            name=CLUSTER_WALLET_NAME,
+            currency=config.currency,
+            country=None,
+            configuration=config.model_dump(),
+        )
+        logger.info(f"Seeded cluster wallet {wallet.id} ({config.credits_url})")
+    elif existing.configuration != config.model_dump():
+        await repository.update_configuration(
+            existing.id, tenant_id, config.model_dump()
+        )
+        logger.info(f"Updated cluster wallet {existing.id} config from env")

--- a/backend/syft_space/components/wallets/wallet_configs.py
+++ b/backend/syft_space/components/wallets/wallet_configs.py
@@ -10,6 +10,7 @@ from enum import Enum
 
 from pydantic import BaseModel
 
+from syft_space.components.wallets.cluster.config import ClusterWalletConfig
 from syft_space.components.wallets.gateway.xendit.config import XenditWalletConfig
 from syft_space.components.wallets.mpp.config import MppWalletConfig
 
@@ -19,6 +20,9 @@ class WalletCategory(str, Enum):
 
     MPP = "mpp"
     GATEWAY = "gateway"
+    # Managed cluster credits: no local top-ups/invoices, balance lives at
+    # the cluster's credits service, spend history is journaled locally.
+    CLUSTER = "cluster"
 
 
 class WalletType(str, Enum):
@@ -26,6 +30,7 @@ class WalletType(str, Enum):
 
     MPP = "mpp"
     XENDIT = "xendit"
+    CLUSTER = "cluster"
 
     @property
     def category(self) -> WalletCategory:
@@ -36,15 +41,18 @@ class WalletType(str, Enum):
 WALLET_TYPE_CATEGORIES: dict[WalletType, WalletCategory] = {
     WalletType.MPP: WalletCategory.MPP,
     WalletType.XENDIT: WalletCategory.GATEWAY,
+    WalletType.CLUSTER: WalletCategory.CLUSTER,
 }
 
 # Maps each wallet type to its Pydantic config class
 WALLET_CONFIG_REGISTRY: dict[WalletType, type[BaseModel]] = {
     WalletType.MPP: MppWalletConfig,
     WalletType.XENDIT: XenditWalletConfig,
+    WalletType.CLUSTER: ClusterWalletConfig,
 }
 
 __all__ = [
+    "ClusterWalletConfig",
     "MppWalletConfig",
     "XenditWalletConfig",
     "WalletCategory",

--- a/backend/syft_space/config.py
+++ b/backend/syft_space/config.py
@@ -132,6 +132,23 @@ class AppSettings(BaseSettings):
         ),
     )
 
+    # Syft Cluster credits (managed wallet) settings
+    cluster_credits_url: HttpUrl | None = Field(
+        default=None,
+        description=(
+            "Base URL of the cluster credits service. Set (with the token) "
+            "to seed the managed cluster wallet at startup."
+        ),
+    )
+    cluster_credits_token: str = Field(
+        default="",
+        description="Per-space service token for the cluster credits API",
+    )
+    cluster_credits_currency: str = Field(
+        default="USD",
+        description="Currency of the cluster credits wallet",
+    )
+
     # Endpoint health check settings
     heartbeat_enabled: bool = Field(
         default=True,
@@ -148,7 +165,9 @@ class AppSettings(BaseSettings):
         description="Timeout in seconds for local chat model/dataset calls",
     )
 
-    @field_validator("public_url", "docling_serve_url", mode="before")
+    @field_validator(
+        "public_url", "docling_serve_url", "cluster_credits_url", mode="before"
+    )
     @classmethod
     def validate_optional_url(cls, v: HttpUrl | str | None) -> HttpUrl | None:
         if not v:

--- a/backend/syft_space/main.py
+++ b/backend/syft_space/main.py
@@ -150,12 +150,14 @@ from syft_space.components.tenants.routes import build_tenant_routes
 from syft_space.components.vector_stores import register_builtin_vector_stores
 
 # Import wallet components
+from syft_space.components.wallets.cluster.provider import ClusterWalletProvider
 from syft_space.components.wallets.gateway.stripe.provider import StripeWalletProvider
 from syft_space.components.wallets.gateway.xendit.provider import XenditWalletProvider
 from syft_space.components.wallets.handlers import WalletHandler
 from syft_space.components.wallets.mpp.provider import MppWalletProvider
 from syft_space.components.wallets.repository import WalletRepository
 from syft_space.components.wallets.routes import build_wallet_routes
+from syft_space.components.wallets.seed import seed_cluster_wallet
 from syft_space.config import app_settings
 
 
@@ -291,6 +293,11 @@ async def lifespan(app: FastAPI):
         tenant_repository, settings_handler
     )
     app.state.default_tenant = default_tenant
+
+    # Seed the managed cluster wallet from SYFT_CLUSTER_CREDITS_* (no-op
+    # for standalone spaces)
+    if default_tenant:
+        await seed_cluster_wallet(wallet_repository, default_tenant.id)
 
     # 2.1. Load diagnostics preference for Sentry gating
     try:
@@ -476,6 +483,7 @@ wallet_providers = {
     "mpp": MppWalletProvider(),
     "xendit": XenditWalletProvider(),
     "stripe": StripeWalletProvider(),
+    "cluster": ClusterWalletProvider(),
 }
 
 # Initialize payment handlers

--- a/backend/tests/test_cluster_wallet.py
+++ b/backend/tests/test_cluster_wallet.py
@@ -1,0 +1,404 @@
+"""Cluster wallet (managed credits): registry, credits client, charger
+journaling, exclusivity guards, and seed-on-boot."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import UUID, uuid4
+
+import httpx
+import pytest
+
+from syft_space.components.payments.cluster.charger import ClusterCreditsCharger
+from syft_space.components.payments.cluster.credits_client import (
+    ClusterCreditsClient,
+    ClusterCreditsError,
+    InsufficientCreditsError,
+)
+from syft_space.components.policy_types.interfaces import BalanceShortfallError
+from syft_space.components.wallets import seed as seed_module
+from syft_space.components.wallets.cluster.config import ClusterWalletConfig
+from syft_space.components.wallets.seed import seed_cluster_wallet
+from syft_space.components.wallets.wallet_configs import (
+    WALLET_CONFIG_REGISTRY,
+    WALLET_TYPE_CATEGORIES,
+    WalletCategory,
+    WalletType,
+)
+from syft_space.config import app_settings
+
+TENANT = uuid4()
+ENDPOINT = uuid4()
+WALLET = uuid4()
+
+# ============== Registry ==============
+
+
+def test_cluster_type_registered_with_own_category():
+    assert WALLET_TYPE_CATEGORIES[WalletType.CLUSTER] is WalletCategory.CLUSTER
+    assert WALLET_CONFIG_REGISTRY[WalletType.CLUSTER] is ClusterWalletConfig
+
+
+def test_cluster_policy_types_require_cluster_wallet():
+    from syft_space.components.policy_types.cluster.cluster_per_request import (
+        ClusterPerRequestPolicy,
+    )
+
+    caps = ClusterPerRequestPolicy.capabilities()
+    assert caps.requires_wallet is True
+    assert caps.required_wallet_type == "cluster"
+
+
+# ============== Credits client ==============
+
+
+class _FakeCreditsServer:
+    def __init__(self, debit_status: int = 200, refund_status: int = 200):
+        self.debit_status = debit_status
+        self.refund_status = refund_status
+        self.requests: list[httpx.Request] = []
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        if request.url.path == "/api/v1/credits/debit":
+            if self.debit_status == 402:
+                return httpx.Response(402, json={"balance": 0.01, "required": 0.05})
+            return httpx.Response(
+                self.debit_status,
+                json={"transaction_id": "x", "balance_after": 9.95},
+            )
+        if request.url.path == "/api/v1/credits/refund":
+            return httpx.Response(self.refund_status, json={"refunded": True})
+        if request.url.path == "/api/v1/credits/balance":
+            return httpx.Response(200, json={"balance": 12.4, "currency": "USD"})
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+
+def _make_client(server: _FakeCreditsServer) -> ClusterCreditsClient:
+    client = ClusterCreditsClient("http://cluster:9000", "space-token")
+    client._build_http_client = lambda: httpx.AsyncClient(  # type: ignore[method-assign]
+        base_url=client.base_url,
+        headers={"Authorization": "Bearer space-token"},
+        transport=httpx.MockTransport(server.handler),
+    )
+    return client
+
+
+async def test_client_debit_sends_contract_payload_and_bearer():
+    server = _FakeCreditsServer()
+    tx = uuid4()
+
+    await _make_client(server).debit(
+        transaction_id=tx,
+        user_email="user@test.com",
+        amount=0.05,
+        endpoint="my-endpoint",
+        charge_unit="request",
+        charge_quantity=1,
+    )
+
+    request = server.requests[0]
+    assert request.headers["authorization"] == "Bearer space-token"
+    body = request.read().decode()
+    for expected in (str(tx), "user@test.com", "0.05", "my-endpoint"):
+        assert expected in body
+
+
+async def test_client_debit_402_raises_insufficient():
+    server = _FakeCreditsServer(debit_status=402)
+
+    with pytest.raises(InsufficientCreditsError) as exc:
+        await _make_client(server).debit(
+            transaction_id=uuid4(),
+            user_email="u@t.co",
+            amount=0.05,
+            endpoint="e",
+            charge_unit="request",
+            charge_quantity=1,
+        )
+    assert exc.value.balance == 0.01
+    assert exc.value.required == 0.05
+
+
+async def test_client_unreachable_raises_credits_error():
+    def refuse(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("connection refused")
+
+    client = ClusterCreditsClient("http://cluster:9000", "t")
+    client._build_http_client = lambda: httpx.AsyncClient(  # type: ignore[method-assign]
+        base_url=client.base_url, transport=httpx.MockTransport(refuse)
+    )
+
+    with pytest.raises(ClusterCreditsError, match="unavailable"):
+        await client.get_balance("u@t.co")
+
+
+async def test_client_refund_tolerates_unknown_transaction():
+    server = _FakeCreditsServer(refund_status=404)
+    await _make_client(server).refund(uuid4())  # must not raise
+
+
+# ============== Charger ==============
+
+
+class _FakeClient:
+    def __init__(self, insufficient: bool = False, unreachable: bool = False):
+        self.insufficient = insufficient
+        self.unreachable = unreachable
+        self.debits: list[dict[str, Any]] = []
+        self.refunds: list[UUID] = []
+
+    async def debit(self, **kwargs):
+        if self.unreachable:
+            raise ClusterCreditsError("cluster credits service unavailable")
+        if self.insufficient:
+            raise InsufficientCreditsError(balance=0.0, required=kwargs["amount"])
+        self.debits.append(kwargs)
+        return {"balance_after": 1.0}
+
+    async def refund(self, transaction_id):
+        self.refunds.append(transaction_id)
+
+    async def get_balance(self, user_email):
+        return 12.4
+
+
+class _FakeBalanceService:
+    def __init__(self, journal_fails: bool = False):
+        self.journal_fails = journal_fails
+        self.debit_records: list[dict[str, Any]] = []
+        self.cancel_records: list[UUID] = []
+
+    async def record_external_debit(self, **kwargs):
+        if self.journal_fails:
+            raise RuntimeError("db down")
+        self.debit_records.append(kwargs)
+
+    async def record_external_cancel(self, transaction_id):
+        if self.journal_fails:
+            raise RuntimeError("db down")
+        self.cancel_records.append(transaction_id)
+
+
+def _make_charger(client, balance_service) -> ClusterCreditsCharger:
+    return ClusterCreditsCharger(
+        client=client,
+        balance_service=balance_service,
+        wallet_id=WALLET,
+        currency="USD",
+        tenant_id=TENANT,
+        endpoint_id=ENDPOINT,
+        endpoint_slug="my-endpoint",
+    )
+
+
+async def test_reserve_debits_then_journals():
+    client, journal = _FakeClient(), _FakeBalanceService()
+    charger = _make_charger(client, journal)
+
+    tx = await charger.reserve(
+        user_email="u@t.co", amount=0.05, charge_unit="request", charge_quantity=1
+    )
+
+    assert client.debits[0]["transaction_id"] == tx
+    assert client.debits[0]["endpoint"] == "my-endpoint"
+    record = journal.debit_records[0]
+    assert record["transaction_id"] == tx
+    assert record["wallet_id"] == WALLET
+    assert record["amount"] == 0.05
+
+
+async def test_reserve_insufficient_maps_to_shortfall_no_journal():
+    client, journal = _FakeClient(insufficient=True), _FakeBalanceService()
+
+    with pytest.raises(BalanceShortfallError) as exc:
+        await _make_charger(client, journal).reserve(
+            user_email="u@t.co", amount=0.05, charge_unit="request", charge_quantity=1
+        )
+    assert exc.value.currency == "USD"
+    assert journal.debit_records == []
+
+
+async def test_reserve_fails_closed_when_cluster_unreachable():
+    client, journal = _FakeClient(unreachable=True), _FakeBalanceService()
+
+    with pytest.raises(ClusterCreditsError):
+        await _make_charger(client, journal).reserve(
+            user_email="u@t.co", amount=0.05, charge_unit="request", charge_quantity=1
+        )
+    assert journal.debit_records == []
+
+
+async def test_journal_failure_does_not_fail_the_query():
+    client = _FakeClient()
+    charger = _make_charger(client, _FakeBalanceService(journal_fails=True))
+
+    tx = await charger.reserve(  # must not raise
+        user_email="u@t.co", amount=0.05, charge_unit="request", charge_quantity=1
+    )
+    assert client.debits[0]["transaction_id"] == tx
+
+
+async def test_cancel_refunds_then_journals():
+    client, journal = _FakeClient(), _FakeBalanceService()
+    tx = uuid4()
+
+    await _make_charger(client, journal).cancel(tx)
+
+    assert client.refunds == [tx]
+    assert journal.cancel_records == [tx]
+
+
+# ============== Seed-on-boot ==============
+
+
+class _FakeWalletRepo:
+    def __init__(self, existing=None):
+        self.existing = existing
+        self.created: list[dict[str, Any]] = []
+        self.updated: list[tuple[UUID, dict]] = []
+
+    async def get_by_type_and_currency(self, wallet_type, currency, tenant_id):
+        return self.existing
+
+    async def create_wallet(self, **kwargs):
+        self.created.append(kwargs)
+
+        class _W:
+            id = uuid4()
+
+        return _W()
+
+    async def update_configuration(self, wallet_id, tenant_id, configuration):
+        self.updated.append((wallet_id, configuration))
+
+    async def get_all(self, tenant_id):
+        return [self.existing] if self.existing else []
+
+
+async def test_seed_noop_without_env():
+    repo = _FakeWalletRepo()
+    await seed_cluster_wallet(repo, TENANT)
+    assert repo.created == []
+
+
+async def test_seed_creates_wallet_from_env(monkeypatch):
+    monkeypatch.setattr(app_settings, "cluster_credits_url", "http://cluster:9000")
+    monkeypatch.setattr(app_settings, "cluster_credits_token", "tok-1")
+    repo = _FakeWalletRepo()
+
+    await seed_cluster_wallet(repo, TENANT)
+
+    created = repo.created[0]
+    assert created["wallet_type"] == "cluster"
+    assert created["currency"] == "USD"
+    assert created["configuration"]["service_token"] == "tok-1"
+
+
+async def test_seed_upserts_rotated_token(monkeypatch):
+    monkeypatch.setattr(app_settings, "cluster_credits_url", "http://cluster:9000")
+    monkeypatch.setattr(app_settings, "cluster_credits_token", "tok-2")
+
+    class _Existing:
+        id = uuid4()
+        configuration = {
+            "credits_url": "http://cluster:9000",
+            "service_token": "tok-1",
+            "currency": "USD",
+        }
+
+    repo = _FakeWalletRepo(existing=_Existing())
+    await seed_cluster_wallet(repo, TENANT)
+
+    assert repo.created == []
+    assert repo.updated[0][1]["service_token"] == "tok-2"
+
+
+async def test_seed_noop_when_config_unchanged(monkeypatch):
+    monkeypatch.setattr(app_settings, "cluster_credits_url", "http://cluster:9000")
+    monkeypatch.setattr(app_settings, "cluster_credits_token", "tok-1")
+
+    class _Existing:
+        id = uuid4()
+        configuration = {
+            "credits_url": "http://cluster:9000",
+            "service_token": "tok-1",
+            "currency": "USD",
+        }
+
+    repo = _FakeWalletRepo(existing=_Existing())
+    await seed_cluster_wallet(repo, TENANT)
+
+    assert repo.created == [] and repo.updated == []
+
+
+def test_seed_module_reads_settings_lazily():
+    # Guard against import-time env capture: the module must consult
+    # app_settings at call time (monkeypatched settings must be honored).
+    assert seed_module.app_settings is app_settings
+
+
+# ============== Exclusivity guards ==============
+
+
+class _GuardRepo:
+    """Repo stub: one cluster wallet present."""
+
+    def __init__(self, wallets):
+        self.wallets = wallets
+
+    async def get_all(self, tenant_id):
+        return self.wallets
+
+    async def get_by_id(self, wallet_id, tenant_id):
+        return next((w for w in self.wallets if w.id == wallet_id), None)
+
+
+class _StubWallet:
+    def __init__(self, wallet_type):
+        self.id = uuid4()
+        self.wallet_type = wallet_type
+
+
+class _StubTenant:
+    id = TENANT
+
+
+@pytest.fixture
+def handler_with_cluster_wallet():
+    from syft_space.components.wallets.handlers import WalletHandler
+
+    handler = WalletHandler.__new__(WalletHandler)
+    handler.repository = _GuardRepo([_StubWallet("cluster")])
+    handler.providers = {}
+    handler.deletion_check = None
+    return handler
+
+
+async def test_create_blocked_while_managed_wallet_exists(
+    handler_with_cluster_wallet,
+):
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        await handler_with_cluster_wallet.create_wallet(
+            "xendit", {"api_key": "x"}, _StubTenant()
+        )
+    assert exc.value.status_code == 403
+
+
+async def test_cluster_type_never_creatable(handler_with_cluster_wallet):
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc:
+        await handler_with_cluster_wallet.create_wallet("cluster", {}, _StubTenant())
+    assert exc.value.status_code == 403
+
+
+async def test_managed_wallet_not_deletable(handler_with_cluster_wallet):
+    from fastapi import HTTPException
+
+    wallet_id = handler_with_cluster_wallet.repository.wallets[0].id
+    with pytest.raises(HTTPException) as exc:
+        await handler_with_cluster_wallet.delete_wallet(wallet_id, _StubTenant())
+    assert exc.value.status_code == 403

--- a/frontend/src/api/types/index.ts
+++ b/frontend/src/api/types/index.ts
@@ -581,6 +581,7 @@ export interface WalletResponse {
   currency: string
   country: string | null
   is_active: boolean
+  managed: boolean
   display: Record<string, string>
   created_at: string
   updated_at: string
@@ -593,6 +594,7 @@ export interface WalletListItem {
   currency: string
   country: string | null
   is_active: boolean
+  managed: boolean
   display: Record<string, string>
   created_at: string
 }

--- a/frontend/src/components/AddPricingRuleDialog.vue
+++ b/frontend/src/components/AddPricingRuleDialog.vue
@@ -282,12 +282,12 @@
               </SelectTrigger>
               <SelectContent>
                 <SelectItem v-for="w in wallets" :key="w.id" :value="w.id">
-                  {{ w.name }} · {{ providerLabel(w.wallet_type) }} · {{ w.currency }}
+                  {{ w.name }} · {{ providerLabel(w) }} · {{ w.currency }}
                 </SelectItem>
               </SelectContent>
             </Select>
             <button
-              v-if="!lockedWalletId"
+              v-if="!lockedWalletId && !hasManagedWallet"
               class="text-xs text-primary hover:text-primary/80 underline-offset-2 hover:underline"
               @click="view = 'pick-provider'"
             >
@@ -385,7 +385,7 @@
                 <span class="text-right font-medium">{{ selectedWallet.name }}</span>
                 <span class="text-muted-foreground">Provider</span>
                 <span class="text-right font-medium">
-                  {{ providerLabel(selectedWallet.wallet_type) }}
+                  {{ providerLabel(selectedWallet) }}
                 </span>
                 <span class="text-muted-foreground">Price</span>
                 <span class="text-right font-medium">
@@ -536,6 +536,10 @@ const selectedWallet = computed(
   () => wallets.value.find((w) => w.id === selectedWalletId.value) ?? null,
 )
 
+// A managed wallet is the only wallet the space may use — hide the inline
+// wallet-setup entry points while it exists (the backend blocks creation too).
+const hasManagedWallet = computed(() => wallets.value.some((w) => w.managed))
+
 const priceHint = computed(() => {
   const price = parseFloat(form.value.price)
   if (isNaN(price) || price <= 0 || !selectedWallet.value) return ''
@@ -565,8 +569,9 @@ const canCreateStripe = computed(
     stripeForm.value.webhookSecret.trim().length > 0,
 )
 
-const providerLabel = (walletType: string): string => {
-  switch (walletType) {
+const providerLabel = (wallet: WalletListItem): string => {
+  if (wallet.managed) return 'Managed'
+  switch (wallet.wallet_type) {
     case 'mpp':
       return 'MPP (Tempo)'
     case 'xendit':
@@ -574,7 +579,7 @@ const providerLabel = (walletType: string): string => {
     case 'stripe':
       return 'Stripe'
     default:
-      return walletType
+      return wallet.wallet_type
   }
 }
 
@@ -616,6 +621,9 @@ const policyTypeForWallet = (walletType: string, chargeMode: ChargeMode): Paymen
   }
   if (walletType === 'stripe') {
     return chargeMode === 'document' ? 'stripe_per_document' : 'stripe_per_request'
+  }
+  if (walletType === 'cluster') {
+    return chargeMode === 'document' ? 'cluster_per_document' : 'cluster_per_request'
   }
   return chargeMode === 'document' ? 'xendit_per_document' : 'xendit_per_request'
 }

--- a/frontend/src/composables/usePolicyCreation.ts
+++ b/frontend/src/composables/usePolicyCreation.ts
@@ -2,6 +2,7 @@ import { ref } from 'vue'
 import { policiesApi } from '@/api/policies/policies'
 import { walletsApi } from '@/api/endpoints/wallets'
 import type { CreatePolicyRequest } from '@/api/types'
+import type { PaymentPolicyType } from '@/config/policyTypes'
 
 export interface PolicyRules {
   access: Array<{ id: string; config: Record<string, unknown> }>
@@ -261,14 +262,7 @@ export function usePolicyCreation() {
         } else if (policyType === 'pricing') {
           walletId = rule.config.walletId as string | undefined
           const walletType = rule.config.walletType as string | undefined
-          const explicitPolicyType = rule.config.policyType as
-            | 'mpp_per_request'
-            | 'xendit_per_request'
-            | 'stripe_per_request'
-            | 'mpp_per_document'
-            | 'xendit_per_document'
-            | 'stripe_per_document'
-            | undefined
+          const explicitPolicyType = rule.config.policyType as PaymentPolicyType | undefined
           // Default when no explicit type: derive from wallet type, defaulting
           // to per-request charging (the most common case).
           const defaultPolicyType =
@@ -276,7 +270,9 @@ export function usePolicyCreation() {
               ? 'mpp_per_request'
               : walletType === 'stripe'
                 ? 'stripe_per_request'
-                : 'xendit_per_request'
+                : walletType === 'cluster'
+                  ? 'cluster_per_request'
+                  : 'xendit_per_request'
           backendPolicyType = explicitPolicyType ?? defaultPolicyType
 
           const userType = rule.config.userType as 'all' | 'specific'

--- a/frontend/src/config/policyTypes.ts
+++ b/frontend/src/config/policyTypes.ts
@@ -7,9 +7,11 @@ export type PaymentPolicyType =
   | 'mpp_per_request'
   | 'xendit_per_request'
   | 'stripe_per_request'
+  | 'cluster_per_request'
   | 'mpp_per_document'
   | 'xendit_per_document'
   | 'stripe_per_document'
+  | 'cluster_per_document'
 
 export interface PolicyConfig {
   id: string

--- a/frontend/src/pages/AnalyticsPage.vue
+++ b/frontend/src/pages/AnalyticsPage.vue
@@ -473,8 +473,16 @@
           >
             <Receipt class="h-5 w-5 text-muted-foreground" />
           </div>
-          <p class="text-sm font-semibold text-foreground mb-1">No payment wallets configured</p>
-          <p class="text-sm text-muted-foreground">Add a wallet to start tracking earnings.</p>
+          <p class="text-sm font-semibold text-foreground mb-1">
+            {{ hasManagedWallet ? 'No invoices to show' : 'No payment wallets configured' }}
+          </p>
+          <p class="text-sm text-muted-foreground">
+            {{
+              hasManagedWallet
+                ? 'This space uses a managed credits wallet — spend is tracked per endpoint.'
+                : 'Add a wallet to start tracking earnings.'
+            }}
+          </p>
         </div>
 
         <template v-else>
@@ -1014,6 +1022,7 @@ const selectedNgramSize = computed({
 
 // ── Earnings state ─────────────────────────────────────────────────────────
 const wallets = ref<WalletListItem[]>([])
+const hasManagedWallet = ref(false)
 const walletsLoading = ref(false)
 const selectedWalletId = ref<string>('')
 const invoicesLoading = ref(false)
@@ -1065,8 +1074,10 @@ const fetchWallets = async () => {
   walletsLoading.value = true
   try {
     const all = await walletsApi.list()
-    // MPP wallets use on-chain transactions, not invoices — exclude them.
-    wallets.value = all.filter((w) => w.wallet_type !== 'mpp')
+    // Only gateway wallets have invoices — MPP settles on-chain and managed
+    // wallets are topped up outside the space, so exclude both.
+    hasManagedWallet.value = all.some((w) => w.managed)
+    wallets.value = all.filter((w) => w.wallet_type !== 'mpp' && !w.managed)
     const first = wallets.value[0]
     if (first && !selectedWalletId.value) {
       selectedWalletId.value = first.id

--- a/frontend/src/pages/CreateDataEndpointPage.vue
+++ b/frontend/src/pages/CreateDataEndpointPage.vue
@@ -1509,7 +1509,12 @@ import {
   generateRuleId,
   createEmptyPolicyRules,
 } from '@/config/policyTypes'
-import type { PolicyTypeId, PolicyRulesRecord, PolicyConfig } from '@/config/policyTypes'
+import type {
+  PaymentPolicyType,
+  PolicyTypeId,
+  PolicyRulesRecord,
+  PolicyConfig,
+} from '@/config/policyTypes'
 import { useFileIcon } from '@/composables/useFileIcon'
 import { useTheme } from '@/composables/useTheme'
 import { MdEditor, MdPreview } from 'md-editor-v3'
@@ -2076,13 +2081,7 @@ const handlePricingRuleCreated = (payload: {
   walletId: string
   walletType: string
   walletCurrency: string
-  policyType:
-    | 'mpp_per_request'
-    | 'xendit_per_request'
-    | 'stripe_per_request'
-    | 'mpp_per_document'
-    | 'xendit_per_document'
-    | 'stripe_per_document'
+  policyType: PaymentPolicyType
   name: string
   config: Record<string, unknown>
 }) => {

--- a/frontend/src/pages/CreateModelEndpointPage.vue
+++ b/frontend/src/pages/CreateModelEndpointPage.vue
@@ -1314,7 +1314,12 @@ import {
   generateRuleId,
   createEmptyPolicyRules,
 } from '@/config/policyTypes'
-import type { PolicyTypeId, PolicyRulesRecord, PolicyConfig } from '@/config/policyTypes'
+import type {
+  PaymentPolicyType,
+  PolicyTypeId,
+  PolicyRulesRecord,
+  PolicyConfig,
+} from '@/config/policyTypes'
 import { useProviderModels } from '@/composables/useProviderModels'
 import { useTheme } from '@/composables/useTheme'
 import { MdEditor, MdPreview } from 'md-editor-v3'
@@ -1812,13 +1817,7 @@ const handlePricingRuleCreated = (payload: {
   walletId: string
   walletType: string
   walletCurrency: string
-  policyType:
-    | 'mpp_per_request'
-    | 'xendit_per_request'
-    | 'stripe_per_request'
-    | 'mpp_per_document'
-    | 'xendit_per_document'
-    | 'stripe_per_document'
+  policyType: PaymentPolicyType
   name: string
   config: Record<string, unknown>
 }) => {

--- a/frontend/src/pages/EndpointDetailPage.vue
+++ b/frontend/src/pages/EndpointDetailPage.vue
@@ -685,7 +685,7 @@
               placeholder="Filter by email..."
               class="h-9 max-w-sm flex-1 min-w-[200px]"
             />
-            <Select v-if="lockedWallet?.wallet_type === 'xendit'" v-model="txnStatusFilter">
+            <Select v-if="walletUsesLedger" v-model="txnStatusFilter">
               <SelectTrigger class="h-9 w-40">
                 <SelectValue placeholder="All statuses" />
               </SelectTrigger>
@@ -768,22 +768,28 @@
             </CardContent>
           </Card>
 
-          <!-- Gateway (Xendit) payments -->
+          <!-- Ledger payments (gateway + managed wallets) -->
           <Card
-            v-else-if="lockedWallet?.wallet_type === 'xendit'"
+            v-else-if="walletUsesLedger"
             class="bg-card/80 backdrop-blur-sm border border-border shadow-sm"
           >
             <CardHeader class="pb-3">
               <CardTitle class="text-base flex items-center gap-2">
                 <CreditCard class="h-4 w-4 text-violet-600 dark:text-violet-400" />
-                Gateway payments
+                {{ lockedWallet?.managed ? 'Credit payments' : 'Gateway payments' }}
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger as-child>
                       <Info class="h-3.5 w-3.5 text-muted-foreground cursor-help" />
                     </TooltipTrigger>
                     <TooltipContent>
-                      <p>Real-money transactions processed via payment gateway</p>
+                      <p>
+                        {{
+                          lockedWallet?.managed
+                            ? 'Credits charged to users of this endpoint'
+                            : 'Real-money transactions processed via payment gateway'
+                        }}
+                      </p>
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
@@ -995,7 +1001,7 @@ import {
 import PolicyFormDialog from '@/components/PolicyFormDialog.vue'
 import AddPricingRuleDialog from '@/components/AddPricingRuleDialog.vue'
 
-import type { PolicyTypeId } from '@/config/policyTypes'
+import type { PaymentPolicyType, PolicyTypeId } from '@/config/policyTypes'
 import { endpointsApi } from '@/api/endpoints/endpoints'
 import { useEndpointsStore } from '@/stores/endpoints'
 import { toast } from 'vue-sonner'
@@ -1259,13 +1265,7 @@ const ensureWallets = (): Promise<void> => {
 const getPricingPolicies = () => {
   return (
     endpoint.value?.policies?.filter(
-      (p) =>
-        p.policy_type === 'mpp_per_request' ||
-        p.policy_type === 'xendit_per_request' ||
-        p.policy_type === 'stripe_per_request' ||
-        p.policy_type === 'mpp_per_document' ||
-        p.policy_type === 'xendit_per_document' ||
-        p.policy_type === 'stripe_per_document',
+      (p) => p.policy_type.endsWith('_per_request') || p.policy_type.endsWith('_per_document'),
     ) || []
   )
 }
@@ -1279,6 +1279,13 @@ const lockedWallet = computed<WalletListItem | null>(() => {
 })
 
 const lockedWalletId = computed(() => lockedWallet.value?.id ?? null)
+
+// Every wallet except MPP settles through the local ledger — gateway wallets
+// via BalanceService, managed wallets via the recorded external journal.
+// MPP transactions live on-chain and come from the marketplace instead.
+const walletUsesLedger = computed(
+  () => !!lockedWallet.value && lockedWallet.value.wallet_type !== 'mpp',
+)
 
 const policyWallet = (policy: {
   policy_type: string
@@ -1310,11 +1317,7 @@ const getPricingPolicySummary = (policy: {
     return 'Pricing rule configured'
   }
 
-  const isPerDocument =
-    policy.policy_type === 'mpp_per_document' ||
-    policy.policy_type === 'xendit_per_document' ||
-    policy.policy_type === 'stripe_per_document'
-  const unit = isPerDocument ? 'document' : 'request'
+  const unit = policy.policy_type.endsWith('_per_document') ? 'document' : 'request'
   return `${config.price} ${currency} per ${unit} ${appliedLabel}`.trim()
 }
 
@@ -1360,7 +1363,7 @@ const filteredLedgerEntries = computed(() => {
 
 const statTransactionCount = computed(() => {
   if (lockedWallet.value?.wallet_type === 'mpp') return filteredMppTransactions.value.length
-  if (lockedWallet.value?.wallet_type === 'xendit') return filteredLedgerEntries.value.length
+  if (walletUsesLedger.value) return filteredLedgerEntries.value.length
   return 0
 })
 
@@ -1368,7 +1371,7 @@ const statUniqueUsers = computed(() => {
   if (lockedWallet.value?.wallet_type === 'mpp') {
     return new Set(filteredMppTransactions.value.map((t) => t.sender_email)).size
   }
-  if (lockedWallet.value?.wallet_type === 'xendit') {
+  if (walletUsesLedger.value) {
     return new Set(filteredLedgerEntries.value.map((e) => e.user_email)).size
   }
   return 0
@@ -1380,7 +1383,7 @@ const statTotalReceived = computed(() => {
     const currency = lockedWallet.value.currency ?? 'USD'
     return `$${formatPrice(total)} ${currency}`
   }
-  if (lockedWallet.value?.wallet_type === 'xendit') {
+  if (walletUsesLedger.value && lockedWallet.value) {
     const debits = filteredLedgerEntries.value.filter((e) => e.type === 'debit')
     const total = debits.reduce((sum, e) => sum + Number(e.amount || 0), 0)
     const currency =
@@ -1421,9 +1424,9 @@ const fetchTransactions = async () => {
         mppTransactions.value = []
       }
       ledgerEntries.value = []
-    } else if (wallet.wallet_type === 'xendit' || wallet.wallet_type === 'stripe') {
-      // Both gateway providers share the same ledger transactions endpoint
-      // — balance moves through BalanceService regardless of the top-up rail.
+    } else {
+      // Gateway and managed wallets share the same ledger transactions
+      // endpoint — every charge is journaled locally regardless of the rail.
       try {
         const page = await paymentsApi.listEndpointTransactions(endpoint.value.id)
         ledgerEntries.value = page.items
@@ -1549,13 +1552,7 @@ const confirmDeletePolicy = async () => {
 const handlePricingCreated = async (payload: {
   walletId: string
   walletType: string
-  policyType:
-    | 'mpp_per_request'
-    | 'xendit_per_request'
-    | 'stripe_per_request'
-    | 'mpp_per_document'
-    | 'xendit_per_document'
-    | 'stripe_per_document'
+  policyType: PaymentPolicyType
   name: string
   config: Record<string, unknown>
 }) => {
@@ -1566,7 +1563,9 @@ const handlePricingCreated = async (payload: {
     ? 'MPP'
     : payload.policyType.startsWith('stripe_')
       ? 'Stripe'
-      : 'Xendit'
+      : payload.policyType.startsWith('cluster_')
+        ? 'Credits'
+        : 'Xendit'
   const policyName = payload.name || `${endpoint.value.name} ${policyLabel} Rule #${ruleIndex}`
 
   try {

--- a/frontend/src/pages/SettingsPage.vue
+++ b/frontend/src/pages/SettingsPage.vue
@@ -186,7 +186,12 @@
               <p class="text-sm text-muted-foreground">Manage your payment wallets</p>
             </div>
           </div>
-          <Button variant="outline" size="sm" @click="addWalletDialogOpen = true">
+          <Button
+            v-if="!hasManagedWallet"
+            variant="outline"
+            size="sm"
+            @click="addWalletDialogOpen = true"
+          >
             <Plus class="h-4 w-4 mr-2" />
             Add Wallet
           </Button>
@@ -215,10 +220,11 @@
             <div class="flex items-center gap-3 min-w-0">
               <div
                 class="h-9 w-9 rounded-lg flex items-center justify-center flex-shrink-0"
-                :class="walletIconBgClass(wallet.wallet_type)"
+                :class="walletIconBgClass(wallet)"
               >
+                <Wallet v-if="wallet.managed" class="h-4 w-4 text-sky-600 dark:text-sky-400" />
                 <Zap
-                  v-if="wallet.wallet_type === 'mpp'"
+                  v-else-if="wallet.wallet_type === 'mpp'"
                   class="h-4 w-4 text-emerald-600 dark:text-emerald-400"
                 />
                 <CreditCard
@@ -242,8 +248,12 @@
                   >
                     {{ wallet.is_active ? 'Active' : 'Inactive' }}
                   </Badge>
+                  <Badge v-if="wallet.managed" variant="secondary" class="text-xs"> Managed </Badge>
                 </div>
-                <p class="text-xs text-muted-foreground font-mono truncate">
+                <p v-if="wallet.managed" class="text-xs text-muted-foreground truncate">
+                  Managed by {{ wallet.display.managed_by || 'your cluster' }}
+                </p>
+                <p v-else class="text-xs text-muted-foreground font-mono truncate">
                   <template v-if="wallet.wallet_type === 'mpp'">
                     {{ wallet.display.wallet_address || 'No address' }}
                   </template>
@@ -273,6 +283,7 @@
                 Manage
               </Button>
               <Button
+                v-if="!wallet.managed"
                 variant="ghost"
                 size="sm"
                 class="text-destructive hover:text-destructive"
@@ -693,7 +704,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, reactive, onMounted, watch } from 'vue'
+import { ref, reactive, computed, onMounted, watch } from 'vue'
 import {
   Settings,
   Globe,
@@ -754,6 +765,11 @@ const diagnosticsEnabled = ref(false)
 const loadingWallets = ref(true)
 const allWallets = ref<WalletListItem[]>([])
 const walletDialogOpen = ref(false)
+
+// A managed wallet is seeded from the environment and is the only wallet
+// the space may use — creation and deletion are disabled while it exists
+// (the backend enforces this too).
+const hasManagedWallet = computed(() => allWallets.value.some((w) => w.managed))
 
 const proxyStatus = reactive({
   connected: false,
@@ -924,11 +940,12 @@ watch(
   },
 )
 
-// Per-provider icon background. MPP → emerald; Xendit → violet; Stripe →
-// indigo (mirrors the inline picker in AddPricingRuleDialog and the SyftHub
-// credits-panel chip colours).
-const walletIconBgClass = (walletType: string): string => {
-  switch (walletType) {
+// Per-provider icon background. Managed → sky; MPP → emerald; Xendit →
+// violet; Stripe → indigo (mirrors the inline picker in AddPricingRuleDialog
+// and the SyftHub credits-panel chip colours).
+const walletIconBgClass = (wallet: WalletListItem): string => {
+  if (wallet.managed) return 'bg-sky-100 dark:bg-sky-900/30'
+  switch (wallet.wallet_type) {
     case 'mpp':
       return 'bg-emerald-100 dark:bg-emerald-900/30'
     case 'stripe':


### PR DESCRIPTION
This pull request introduces support for cluster-managed credits wallets and cluster credits payment policies. It adds a new wallet type ("cluster") that is managed externally by the Syft Cluster, integrates a new payment flow for debiting and journaling credits via a cluster credits service, and introduces corresponding payment policies. The API and wallet handler logic are updated to recognize and restrict operations on cluster-managed wallets, ensuring they cannot be created or deleted through the standard API. The most important changes are:

**Cluster Credits Wallet Integration:**

* Added `ClusterWalletConfig` (`wallets/cluster/config.py`) and `ClusterWalletProvider` (`wallets/cluster/provider.py`) to represent and manage the configuration for cluster-managed credits wallets. These wallets are seeded from environment variables and cannot be created or deleted via the API. [[1]](diffhunk://#diff-b8141b369e5d77c4382d1fc23b4e3848ac0f50add18ce305c76c78e2a2fbfc7aR1-R19) [[2]](diffhunk://#diff-f59b65de42f72fdd97556ffb827fa40a00d4cca7066ed2f9e2b820d0fdcfe090R1-R34)
* Updated `WalletHandler` (`wallets/handlers.py`) to recognize cluster wallets, block creation/deletion via the API, and mark them as managed in wallet listings and responses. [[1]](diffhunk://#diff-ec8b1b1a5e4a63cd516b569b05c8705979bcdb9a3cf0f43fec4751b49fb2aeb9R55-R59) [[2]](diffhunk://#diff-ec8b1b1a5e4a63cd516b569b05c8705979bcdb9a3cf0f43fec4751b49fb2aeb9R75) [[3]](diffhunk://#diff-ec8b1b1a5e4a63cd516b569b05c8705979bcdb9a3cf0f43fec4751b49fb2aeb9R97) [[4]](diffhunk://#diff-ec8b1b1a5e4a63cd516b569b05c8705979bcdb9a3cf0f43fec4751b49fb2aeb9R115-R120) [[5]](diffhunk://#diff-ec8b1b1a5e4a63cd516b569b05c8705979bcdb9a3cf0f43fec4751b49fb2aeb9R145-R161)

**Cluster Credits Charging Flow:**

* Implemented `ClusterCreditsCharger` (`payments/cluster/charger.py`) which debits user balances via the cluster credits service and journals transactions locally for history and reconciliation.
* Added `ClusterCreditsClient` (`payments/cluster/credits_client.py`) to interact with the cluster credits API for debit, refund, and balance operations, with robust error handling.
* Updated `build_payment_chargers` to instantiate and use the new `ClusterCreditsCharger` when a cluster wallet is present. [[1]](diffhunk://#diff-1b31cbf3f7f9a353f4d9d64c4b75d7ffdee13e3dc10e756c3e5a962a435dea56R12-R13) [[2]](diffhunk://#diff-1b31cbf3f7f9a353f4d9d64c4b75d7ffdee13e3dc10e756c3e5a962a435dea56R57-R69)

**Journaling and Policy Support:**

* Extended `BalanceService` with methods to record external debits and cancellations for cluster wallet transactions, ensuring local history without affecting balances.
* Introduced `ClusterPerRequestPolicy` and `ClusterPerDocumentPolicy` (`policy_types/cluster/cluster_per_request.py`, `policy_types/cluster/cluster_per_document.py`) as new payment policies, inheriting from prepaid balance policies, and registered them as built-in types. [[1]](diffhunk://#diff-6ea68fc5d0ed6a1299d091caec9b87313809aff44cc8b9cea2482ec8b16a81edR1-R22) [[2]](diffhunk://#diff-069a82c152229cae99130d51af6bc9b63d5a2015b05db796c1708c738b7c25c7R1-R22) [[3]](diffhunk://#diff-3bf991e1cb21d24781e823046ed63e7a303774f4909b1f5da40002aa0ccf49a3R19-R20) [[4]](diffhunk://#diff-3bf991e1cb21d24781e823046ed63e7a303774f4909b1f5da40002aa0ccf49a3R38-R39)

**Other:**

* Added a new module for cluster policy types (`policy_types/cluster/__init__.py`).

These changes collectively enable seamless, auditable use of cluster-managed credits for payment in Syft spaces, with clear separation and protection of cluster-managed resources.