### PR TITLE
Refactor managed-wallet display to be provider-neutral

### DIFF
--- a/backend/syft_space/components/wallets/cluster/provider.py
+++ b/backend/syft_space/components/wallets/cluster/provider.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 
 from syft_space.components.wallets.cluster.config import ClusterWalletConfig
 from syft_space.components.wallets.interfaces import SetupResult
+from syft_space.config import app_settings
 
 
 class ClusterWalletProvider:
@@ -23,12 +24,11 @@ class ClusterWalletProvider:
 
     async def setup_wallet(self, raw_credentials: dict[str, Any]) -> SetupResult:
         raise ValueError(
-            "Cluster wallets are managed by the cluster and cannot be "
-            "created through the API"
+            "This wallet is managed externally and cannot be created through the API"
         )
 
     def extract_display(
         self, configuration: dict[str, Any], wallet_id: UUID
     ) -> dict[str, Any]:
         """Safe display info — never the service token."""
-        return {"managed_by": "Your cluster"}
+        return {"managed_by": app_settings.cluster_managed_by}

--- a/backend/syft_space/components/wallets/handlers.py
+++ b/backend/syft_space/components/wallets/handlers.py
@@ -115,7 +115,7 @@ class WalletHandler:
         if wallet.wallet_type == WalletType.CLUSTER.value:
             raise HTTPException(
                 status_code=403,
-                detail="This wallet is managed by the cluster and cannot be deleted",
+                detail="This wallet is managed externally and cannot be deleted",
             )
 
         if not force and self.deletion_check is not None:
@@ -143,13 +143,14 @@ class WalletHandler:
         and (optionally) country alongside the configuration. The handler
         enforces (tenant, wallet_type, currency) uniqueness.
 
-        Blocked entirely while a cluster-managed wallet exists — members
-        of a Syft Cluster can only use the managed credits wallet.
+        Blocked entirely while a managed wallet exists — spaces with a
+        managed credits wallet can only use that wallet.
         """
         if wallet_type == WalletType.CLUSTER.value:
             raise HTTPException(
                 status_code=403,
-                detail="Cluster wallets are seeded by the cluster, not created here",
+                detail="Managed wallets are seeded from the environment, "
+                "not created here",
             )
         if await self._has_managed_wallet(tenant.id):
             raise HTTPException(
@@ -241,7 +242,7 @@ class WalletHandler:
             raise HTTPException(
                 status_code=403,
                 detail=(
-                    "This wallet is managed by the cluster — its config "
+                    "This wallet is managed externally — its config "
                     "comes from the environment"
                 ),
             )

--- a/backend/syft_space/components/wallets/seed.py
+++ b/backend/syft_space/components/wallets/seed.py
@@ -1,6 +1,6 @@
 """Seed the managed cluster wallet from env at startup.
 
-Spaces provisioned into a Syft Cluster get ``SYFT_CLUSTER_CREDITS_URL``
+Spaces provisioned into a cluster get ``SYFT_CLUSTER_CREDITS_URL``
 and ``SYFT_CLUSTER_CREDITS_TOKEN`` in their Secret. This hook upserts the
 matching wallet so billing works without any UI action: create it when
 missing, refresh the stored config when the env changed (token rotation
@@ -17,7 +17,7 @@ from syft_space.config import app_settings
 
 logger = logging.getLogger(__name__)
 
-CLUSTER_WALLET_NAME = "Cluster Shared Wallet"
+CLUSTER_WALLET_NAME = "Managed Credits Wallet"
 
 
 async def seed_cluster_wallet(repository: WalletRepository, tenant_id: UUID) -> None:

--- a/backend/syft_space/config.py
+++ b/backend/syft_space/config.py
@@ -148,6 +148,13 @@ class AppSettings(BaseSettings):
         default="USD",
         description="Currency of the cluster credits wallet",
     )
+    cluster_managed_by: str = Field(
+        default="Syft Space Host",
+        description=(
+            "Display name of whoever manages the credits wallet, shown to "
+            "members as 'Managed by <name>'."
+        ),
+    )
 
     # Endpoint health check settings
     heartbeat_enabled: bool = Field(

--- a/backend/tests/test_cluster_wallet.py
+++ b/backend/tests/test_cluster_wallet.py
@@ -338,6 +338,19 @@ def test_seed_module_reads_settings_lazily():
     assert seed_module.app_settings is app_settings
 
 
+def test_display_managed_by_from_env(monkeypatch):
+    from syft_space.components.wallets.cluster.provider import ClusterWalletProvider
+    from syft_space.config import AppSettings
+
+    provider = ClusterWalletProvider()
+    monkeypatch.setattr(app_settings, "cluster_managed_by", "Acme Research Station")
+    assert provider.extract_display({}, uuid4()) == {
+        "managed_by": "Acme Research Station"
+    }
+
+    assert AppSettings.model_fields["cluster_managed_by"].default == "Syft Space Host"
+
+
 # ============== Exclusivity guards ==============
 
 

--- a/frontend/src/pages/SettingsPage.vue
+++ b/frontend/src/pages/SettingsPage.vue
@@ -251,7 +251,7 @@
                   <Badge v-if="wallet.managed" variant="secondary" class="text-xs"> Managed </Badge>
                 </div>
                 <p v-if="wallet.managed" class="text-xs text-muted-foreground truncate">
-                  Managed by {{ wallet.display.managed_by || 'your cluster' }}
+                  Managed by {{ wallet.display.managed_by || 'Syft Space Host' }}
                 </p>
                 <p v-else class="text-xs text-muted-foreground font-mono truncate">
                   <template v-if="wallet.wallet_type === 'mpp'">


### PR DESCRIPTION
This pull request updates the terminology and configuration for managed wallets, making the system more flexible and less cluster-specific. The changes introduce a configurable display name for the managed wallet provider, improve clarity in user-facing messages, and ensure the frontend and backend are consistent. The most important changes are:

**Backend improvements and terminology updates:**
* Changed all references from "cluster wallet" to "managed wallet" for clarity and flexibility in backend logic and error messages, including in `provider.py`, `handlers.py`, and `seed.py`. [[1]](diffhunk://#diff-f59b65de42f72fdd97556ffb827fa40a00d4cca7066ed2f9e2b820d0fdcfe090L26-R34) [[2]](diffhunk://#diff-ec8b1b1a5e4a63cd516b569b05c8705979bcdb9a3cf0f43fec4751b49fb2aeb9L118-R118) [[3]](diffhunk://#diff-ec8b1b1a5e4a63cd516b569b05c8705979bcdb9a3cf0f43fec4751b49fb2aeb9L146-R153) [[4]](diffhunk://#diff-ec8b1b1a5e4a63cd516b569b05c8705979bcdb9a3cf0f43fec4751b49fb2aeb9L244-R245) [[5]](diffhunk://#diff-6c02fe12dc54167bb1c23b18a58a92fe9c8d87d7dcc3850a127bfea5ea87cbdaL3-R3) [[6]](diffhunk://#diff-6c02fe12dc54167bb1c23b18a58a92fe9c8d87d7dcc3850a127bfea5ea87cbdaL20-R20)
* Added a new `cluster_managed_by` field to `AppSettings` (`config.py`), allowing the display name of the wallet manager to be set via configuration.

**Frontend consistency:**
* Updated the managed wallet display in `SettingsPage.vue` to use the new default "Syft Space Host" or the configured value, instead of "your cluster".

**Configuration and testing:**
* Updated `extract_display` in `ClusterWalletProvider` to use the configurable `cluster_managed_by` value, and added a test to ensure this value is correctly read from the environment. [[1]](diffhunk://#diff-f59b65de42f72fdd97556ffb827fa40a00d4cca7066ed2f9e2b820d0fdcfe090R15) [[2]](diffhunk://#diff-bc5f6a0f933079e6ca34ec466a1c0a999df4d83fa91d3b3044dacca808b4a506R341-R353)

These changes make managed wallet messaging and branding more adaptable for different deployment scenarios.