### PR TITLE
Add 'just pause' command to stop cluster while preserving volumes

### DIFF
--- a/station/CLAUDE.md
+++ b/station/CLAUDE.md
@@ -143,9 +143,11 @@ The `admin` argument sets
 An optional `hub=http://localhost:8080` argument sets
 `SYFT_STATION_SYFTHUB_URL` (omitted → the production SyftHub default); use
 plain localhost for a local hub — CORS for the hub's browser origin is
-derived from it. An optional `space=tag` argument builds + imports a local
-syft-space image (`just space-image`) and sets `SYFT_STATION_SPACE_VERSION`
-so onboarding suggests that tag. The chart preserves the session secret
+derived from it. Both loops self-seed the syft-space `:dev`
+image — built + imported only when missing from the cluster node — and set
+`SYFT_STATION_SPACE_VERSION` so onboarding suggests it. An explicit
+`space=tag` argument force-rebuilds that tag (the flow after syft-space code
+changes); `space=none` runs on published images only. The chart preserves the session secret
 across `helm upgrade` (via a live `lookup`), so cookies survive redeploys.
 Otherwise spaces pull the published image (`ghcr.io/openmined/syft-space`)
 at whatever tag the admin picks; nothing is baked in.

--- a/station/CLAUDE.md
+++ b/station/CLAUDE.md
@@ -140,10 +140,13 @@ suggests `station.localhost` as the domain (derived from
 plain-http in dev (`SYFT_STATION_SPACE_SCHEME` / `spaces.scheme` — no certs).
 The `admin` argument sets
 `SYFT_STATION_ADMIN_EMAIL` — without it every sign-in gets the member role.
-An optional `hub=http://localhost:8080` argument sets
-`SYFT_STATION_SYFTHUB_URL` (omitted → the production SyftHub default); use
-plain localhost for a local hub — CORS for the hub's browser origin is
-derived from it. Both loops self-seed the syft-space `:dev`
+An optional `hub=http://syfthub.localhost:8080` argument sets
+`SYFT_STATION_SYFTHUB_URL` (omitted → the production SyftHub default).
+`syfthub.localhost` is the canonical name for a host-run local hub: browsers
+and host processes resolve it to loopback natively, and `cluster-dns` maps it
+to the host machine inside the cluster — the SAME hub URL works everywhere
+(never use `host.k3d.internal` or plain `localhost`, which only resolve in
+one of those worlds). CORS for the hub's browser origin is derived from it. Both loops self-seed the syft-space `:dev`
 image — built + imported only when missing from the cluster node — and set
 `SYFT_STATION_SPACE_VERSION` so onboarding suggests it. An explicit
 `space=tag` argument force-rebuilds that tag (the flow after syft-space code

--- a/station/CLAUDE.md
+++ b/station/CLAUDE.md
@@ -150,7 +150,12 @@ one of those worlds). CORS for the hub's browser origin is derived from it. Both
 image — built + imported only when missing from the cluster node — and set
 `SYFT_STATION_SPACE_VERSION` so onboarding suggests it. An explicit
 `space=tag` argument force-rebuilds that tag (the flow after syft-space code
-changes); `space=none` runs on published images only. The chart preserves the session secret
+changes); `space=none` runs on published images only. Spaces in both loops
+see the host's home directory read-only at `~/host-home`: the flag
+(`spaces.hostMount` / `SYFT_STATION_SPACE_HOST_MOUNT`, default off) mounts
+the node's `/mnt/host-home` into every space inside the space's home (the
+dataset file browser is rooted at home and rejects paths outside it), and
+the dev cluster maps `$HOME` to that node path at creation. The chart preserves the session secret
 across `helm upgrade` (via a live `lookup`), so cookies survive redeploys.
 Otherwise spaces pull the published image (`ghcr.io/openmined/syft-space`)
 at whatever tag the admin picks; nothing is baked in.

--- a/station/backend/syft_station/components/provision/manifests.py
+++ b/station/backend/syft_station/components/provision/manifests.py
@@ -21,6 +21,14 @@ TEMPLATE_DIR = Path(__file__).parent.parent.parent / "k8s" / "space"
 # Label carrying the space slug; selects a space's whole resource bundle.
 LABEL_SPACE = "syftcluster.openmined.org/space"
 
+# Host-mount (space_host_mount): the node directory mounted into each space,
+# and the container path where the space sees it. The container path lives
+# INSIDE the container's home directory because syft-space's dataset file
+# browser is rooted at home and refuses paths outside it — anywhere else and
+# the mounted files would be invisible to the picker.
+HOST_MOUNT_NODE_PATH = "/mnt/host-home"
+HOST_MOUNT_PATH = "/root/host-home"
+
 # Rendered in a fixed apply order (Secret/PVC before the Deployment that
 # mounts them; Service before Ingress).
 MANIFEST_FILES: tuple[tuple[str, str], ...] = (
@@ -48,6 +56,7 @@ class RenderSettings(Protocol):
     chromadb_port: int
     docling_url: str
     managed_by_name: str
+    space_host_mount: bool
     syfthub_url: object  # str | pydantic HttpUrl — rendered via str()
 
 
@@ -115,4 +124,23 @@ def render_space_manifests(
             manifests["secret"]["stringData"]["SYFT_CLUSTER_BUNDLES"] = (
                 spec.credits_bundles
             )
+    # The host-mount is conditional structure like the credits keys —
+    # injected, not templated. Read-only: spaces read the mounted files as
+    # data sources; nothing under the mount is theirs to write.
+    if settings.space_host_mount:
+        pod = manifests["deployment"]["spec"]["template"]["spec"]
+        pod["volumes"].append(
+            {
+                "name": "host-home",
+                "hostPath": {
+                    "path": HOST_MOUNT_NODE_PATH,
+                    # OrCreate: a node with nothing mapped at the path serves
+                    # an empty dir instead of a pod stuck ContainerCreating.
+                    "type": "DirectoryOrCreate",
+                },
+            }
+        )
+        pod["containers"][0]["volumeMounts"].append(
+            {"name": "host-home", "mountPath": HOST_MOUNT_PATH, "readOnly": True}
+        )
     return manifests

--- a/station/backend/syft_station/config.py
+++ b/station/backend/syft_station/config.py
@@ -147,6 +147,16 @@ class AppSettings(BaseSettings):
     space_cpu_limit: str = Field(default="1")
     space_memory_request: str = Field(default="512Mi")
     space_memory_limit: str = Field(default="2Gi")
+    space_host_mount: bool = Field(
+        default=False,
+        description=(
+            "Mount the cluster node's /mnt/host-home directory into every "
+            "space, read-only at /root/host-home — inside the container's "
+            "home, where the space's dataset file browser is rooted. What "
+            "spaces see is whatever the cluster runtime maps to that node "
+            "path (the k3d dev cluster maps $HOME there at creation)."
+        ),
+    )
 
     # Shared infrastructure each space connects to (in-cluster service DNS)
     chromadb_host: str = Field(

--- a/station/backend/syft_station/config.py
+++ b/station/backend/syft_station/config.py
@@ -53,10 +53,10 @@ class AppSettings(BaseSettings):
         description=(
             "Extra browser origins allowed by CORS, comma-separated. The "
             "SyftHub origin is always allowed (its frontend calls the buyer "
-            "credits routes from the browser); use this when the hub is "
-            "browsed at a different address than the station dials it "
-            "(e.g. dev: hub configured as host.k3d.internal:8080 but "
-            "browsed at localhost:8080)."
+            "credits routes from the browser); use this only when the hub is "
+            "browsed at a different address than the station dials it. The "
+            "k3d dev loop doesn't need it — syfthub.localhost resolves both "
+            "in browsers and in-cluster (justfile cluster-dns)."
         ),
     )
     admin_email: str = Field(

--- a/station/backend/tests/test_k8s_provisioner.py
+++ b/station/backend/tests/test_k8s_provisioner.py
@@ -28,6 +28,7 @@ SETTINGS = SimpleNamespace(
     chromadb_port=8100,
     docling_url="http://docling-serve:5001",
     managed_by_name="Syft Station",
+    space_host_mount=False,
     syfthub_url="https://hub.test",
     provision_timeout_seconds=5,
     provision_poll_interval_seconds=0.01,

--- a/station/backend/tests/test_manifests.py
+++ b/station/backend/tests/test_manifests.py
@@ -24,6 +24,7 @@ SETTINGS = SimpleNamespace(
     chromadb_port=8100,
     docling_url="http://docling-serve:5001",
     managed_by_name="Syft Station",
+    space_host_mount=False,
     syfthub_url="https://hub.test/",
 )
 
@@ -139,6 +140,37 @@ def test_deployment_mounts_pvc_at_data(manifests):
     container = pod["containers"][0]
     assert container["volumeMounts"][0]["mountPath"] == "/data"
     assert pod["volumes"][0]["persistentVolumeClaim"]["claimName"] == "space-alpha"
+
+
+def test_no_host_mount_by_default(manifests):
+    # Flag off: no hostPath volume reaches the pod at all.
+    pod = manifests["deployment"]["spec"]["template"]["spec"]
+    assert not any("hostPath" in v for v in pod["volumes"])
+    assert all(m["mountPath"] == "/data" for m in pod["containers"][0]["volumeMounts"])
+
+
+def test_host_mount_flag_adds_readonly_hostpath():
+    settings = SimpleNamespace(**{**vars(SETTINGS), "space_host_mount": True})
+    pod = render_space_manifests(SPEC, settings)["deployment"]["spec"]["template"][
+        "spec"
+    ]
+    volume = next(v for v in pod["volumes"] if "hostPath" in v)
+    # OrCreate: a node with nothing mapped at the path serves an empty dir
+    # rather than a pod stuck ContainerCreating.
+    assert volume["hostPath"] == {
+        "path": "/mnt/host-home",
+        "type": "DirectoryOrCreate",
+    }
+    mount = next(
+        m for m in pod["containers"][0]["volumeMounts"] if m["name"] == volume["name"]
+    )
+    # Inside the container's home — the space's file browser is rooted there
+    # and rejects paths outside it.
+    assert mount == {
+        "name": "host-home",
+        "mountPath": "/root/host-home",
+        "readOnly": True,
+    }
 
 
 def test_deployment_health_probes_hit_the_contract_path(manifests):

--- a/station/chart/templates/station/deployment.yaml
+++ b/station/chart/templates/station/deployment.yaml
@@ -59,6 +59,8 @@ spec:
               value: {{ .Values.spaces.memoryLimit | quote }}
             - name: SYFT_STATION_SPACE_SCHEME
               value: {{ .Values.spaces.scheme | quote }}
+            - name: SYFT_STATION_SPACE_HOST_MOUNT
+              value: {{ .Values.spaces.hostMount | quote }}
             - name: SYFT_STATION_MANAGED_BY_NAME
               value: {{ .Values.spaces.managedByName | quote }}
             - name: SYFT_STATION_CHROMADB_HOST

--- a/station/chart/templates/station/rbac.yaml
+++ b/station/chart/templates/station/rbac.yaml
@@ -29,9 +29,21 @@ rules:
   - apiGroups: [apps]
     resources: [deployments]
     verbs: [get, create, patch, delete]
-  # Live status derivation
+  # Live status derivation — the spaces list and the provisioning wait's poll
   - apiGroups: [apps]
     resources: [deployments/status]
+    verbs: [get]
+  # The provisioning wait also inspects the space's pods each poll tick (to
+  # fail fast on terminal states instead of burning the timeout) and tails a
+  # crashed container's logs for a specific failure message. Without these,
+  # the first in-cluster provision 403'd whenever the pod wasn't ready by the
+  # first tick — while a retry, finding the Deployment already available,
+  # never reached the pod inspection and "healed" it.
+  - apiGroups: [""]
+    resources: [pods]
+    verbs: [list]
+  - apiGroups: [""]
+    resources: [pods/log]
     verbs: [get]
   # Pause/resume (scale to 0/1)
   - apiGroups: [apps]

--- a/station/chart/values-dev.yaml
+++ b/station/chart/values-dev.yaml
@@ -33,6 +33,9 @@ spaces:
   image: ghcr.io/openmined/syft-space
   # No certs in dev — spaces are plain http behind the k3d Traefik.
   scheme: http
+  # Spaces see the host's home directory read-only at ~/host-home (the k3d
+  # cluster maps $HOME to the node's /mnt/host-home at creation).
+  hostMount: true
 
 chromadb:
   persistence:

--- a/station/chart/values.yaml
+++ b/station/chart/values.yaml
@@ -98,6 +98,12 @@ spaces:
   memoryLimit: 2Gi
   # Display name injected into spaces as SYFT_CLUSTER_MANAGED_BY.
   managedByName: Syft Station
+  # Mount the node's /mnt/host-home into every space, read-only at
+  # /root/host-home (inside the space's home, where its dataset file browser
+  # is rooted). Spaces see whatever the cluster runtime maps to that node
+  # path — enabled in values-dev.yaml, where the k3d cluster maps $HOME
+  # there at creation.
+  hostMount: false
 
 # ---------------------------------------------------------------------------
 # Shared ChromaDB — one instance, one Chroma *database* per space. Service

--- a/station/frontend/src/components/SetupStationDialog.vue
+++ b/station/frontend/src/components/SetupStationDialog.vue
@@ -14,6 +14,7 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import VersionSelect from '@/components/VersionSelect.vue'
 import WalletSetupForm from '@/components/WalletSetupForm.vue'
+import WalletSummaryCard from '@/components/WalletSummaryCard.vue'
 import { ApiError } from '@/api/client'
 import { useStationStore } from '@/stores/station'
 
@@ -70,9 +71,11 @@ const domainValid = computed(() => {
 
 // Step 2 — optional shared wallet. The fields, validation, and save live in
 // WalletSetupForm (shared with the Earnings dialog); this wizard only owns
-// the skip/advance buttons.
+// the skip/advance buttons. When a wallet is already saved (setup re-run),
+// the step offers it as-is and only unfolds the form to replace it.
 const walletForm = ref<InstanceType<typeof WalletSetupForm> | null>(null)
 const savingWallet = ref(false)
+const replacingWallet = ref(false)
 
 // Step 3 — Syft Space version (image tag from the registry)
 const versionInput = ref('')
@@ -256,25 +259,60 @@ async function finish() {
       <!-- Step 2: optional shared wallet. v-show (not v-if) so the form's
            state — including a minted hub token — survives Back/Next. -->
       <div v-show="step === 1" class="space-y-4">
-        <p class="text-xs text-muted-foreground">
-          One gateway account for the whole station: users buy credits here and spend them at any
-          space; you pay members for what users spend. Skip it to run without pooled payments — you
-          can add it later from Earnings.
-        </p>
-        <WalletSetupForm ref="walletForm" />
-        <div class="flex items-center justify-between">
-          <Button variant="ghost" size="sm" @click="step = 0">
-            <ArrowLeft class="mr-1.5 h-3.5 w-3.5" />
-            Back
-          </Button>
-          <div class="flex gap-2">
-            <Button variant="outline" @click="nextFromWallet(false)">Skip for now</Button>
-            <Button :disabled="savingWallet" @click="nextFromWallet(true)">
-              Add wallet
-              <ArrowRight class="ml-1.5 h-3.5 w-3.5" />
+        <!-- A wallet already exists: offer it as-is, unfold the form to replace. -->
+        <template v-if="station.wallet && !replacingWallet">
+          <p class="text-xs text-muted-foreground">
+            This station already has a shared wallet — users buy credits through it and spend them
+            at any space. Keep using it, or replace the provider account behind it.
+          </p>
+          <WalletSummaryCard />
+          <div class="flex items-center justify-between">
+            <Button variant="ghost" size="sm" @click="step = 0">
+              <ArrowLeft class="mr-1.5 h-3.5 w-3.5" />
+              Back
             </Button>
+            <div class="flex gap-2">
+              <Button variant="outline" @click="replacingWallet = true">Replace…</Button>
+              <Button @click="step = 2">
+                Use this wallet
+                <ArrowRight class="ml-1.5 h-3.5 w-3.5" />
+              </Button>
+            </div>
           </div>
-        </div>
+        </template>
+
+        <template v-else>
+          <p v-if="!station.wallet" class="text-xs text-muted-foreground">
+            One gateway account for the whole station: users buy credits here and spend them at any
+            space; you pay members for what users spend. Skip it to run without pooled payments —
+            you can add it later from Earnings.
+          </p>
+          <WalletSetupForm ref="walletForm" />
+          <div class="flex items-center justify-between">
+            <Button
+              v-if="replacingWallet"
+              variant="ghost"
+              size="sm"
+              @click="replacingWallet = false"
+            >
+              <ArrowLeft class="mr-1.5 h-3.5 w-3.5" />
+              Keep existing
+            </Button>
+            <Button v-else variant="ghost" size="sm" @click="step = 0">
+              <ArrowLeft class="mr-1.5 h-3.5 w-3.5" />
+              Back
+            </Button>
+            <div class="flex gap-2">
+              <Button v-if="!station.wallet" variant="outline" @click="nextFromWallet(false)">
+                Skip for now
+              </Button>
+              <Button :disabled="savingWallet" @click="nextFromWallet(true)">
+                {{ station.wallet ? 'Replace wallet' : 'Add wallet' }}
+                <ArrowRight class="ml-1.5 h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+        </template>
       </div>
 
       <!-- Step 3: version -->

--- a/station/frontend/src/components/WalletSetupForm.vue
+++ b/station/frontend/src/components/WalletSetupForm.vue
@@ -16,6 +16,7 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import WalletSummaryCard from '@/components/WalletSummaryCard.vue'
 import type { WalletProvider } from '@/lib/types'
 import { useStationStore } from '@/stores/station'
 
@@ -29,13 +30,25 @@ import { useStationStore } from '@/stores/station'
 
 const station = useStationStore()
 
-// Mounted fresh each time a host shows it, so initializers read the current
-// wallet (replace mode) or fall back to defaults (create mode).
-const provider = ref<WalletProvider>(station.wallet?.provider ?? 'xendit')
-const currency = ref(station.wallet?.currency ?? 'PHP')
+const provider = ref<WalletProvider>('xendit')
+const currency = ref('PHP')
 const apiKey = ref('')
 const webhookSecret = ref('')
 const saving = ref(false)
+
+// Replace mode mirrors the SAVED wallet. A watcher (not mount-time init):
+// the form can mount before loadWallet resolves — onboarding renders it with
+// the dialog — and a snapshot would lock the wrong currency into the save.
+watch(
+  () => station.wallet,
+  (wallet) => {
+    if (wallet) {
+      provider.value = wallet.provider
+      currency.value = wallet.currency
+    }
+  },
+  { immediate: true },
+)
 
 /**
  * Per-provider currency menus — mirrors the backend's provider-split bundle
@@ -155,6 +168,15 @@ defineExpose({ save, saving })
 
 <template>
   <div class="space-y-4">
+    <!-- Replace mode: show what's being replaced and what survives it. -->
+    <template v-if="station.wallet">
+      <WalletSummaryCard />
+      <p class="text-xs text-muted-foreground">
+        Replacing swaps the provider account behind this wallet — user balances and connected spaces
+        stay as they are.
+      </p>
+    </template>
+
     <div class="grid gap-4 sm:grid-cols-2">
       <div class="space-y-1.5">
         <Label>Provider</Label>

--- a/station/frontend/src/components/WalletSummaryCard.vue
+++ b/station/frontend/src/components/WalletSummaryCard.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+import { Wallet } from 'lucide-vue-next'
+import { Badge } from '@/components/ui/badge'
+import { useStationStore } from '@/stores/station'
+
+/** The saved wallet at a glance — provider, currency, hub connection. */
+
+const station = useStationStore()
+
+const PROVIDER_LABELS: Record<string, string> = { xendit: 'Xendit', stripe: 'Stripe' }
+</script>
+
+<template>
+  <div
+    v-if="station.wallet"
+    class="flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2.5 text-sm"
+  >
+    <Wallet class="h-4 w-4 shrink-0 text-muted-foreground" />
+    <span class="font-medium">
+      {{ PROVIDER_LABELS[station.wallet.provider] ?? station.wallet.provider }}
+    </span>
+    <Badge variant="secondary">{{ station.wallet.currency }}</Badge>
+    <Badge v-if="station.wallet.hubConnected" variant="secondary">SyftHub connected</Badge>
+  </div>
+</template>

--- a/station/justfile
+++ b/station/justfile
@@ -100,10 +100,15 @@ cluster: ensure-cluster
 
 # So space-to-space (and SyftHub-to-space) calls hit the same public URLs the
 # browser uses. Without this, in-cluster lookups of the .localhost hostnames
-# fail (they only resolve to 127.0.0.1 in host browsers). ClusterIP is
-# re-derived live since it can change when the cluster is recreated.
+# fail (they only resolve to 127.0.0.1 in host browsers). The IPs are
+# re-derived live since they can change when the cluster is recreated.
+#
+# syfthub.localhost is the canonical name for a HOST-RUN dev hub: browsers and
+# host processes resolve it to 127.0.0.1 (RFC 6761), and this mapping makes
+# pods resolve it to the host machine — one hub URL that works everywhere,
+# instead of the pods-only host.k3d.internal.
 
-# Resolve *.station.localhost to Traefik inside the cluster (split-horizon DNS).
+# Map *.station.localhost -> Traefik and syfthub.localhost -> this host, in-cluster.
 cluster-dns:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -112,6 +117,14 @@ cluster-dns:
     echo "Waiting for Traefik..."
     until kubectl -n kube-system get svc traefik >/dev/null 2>&1; do sleep 2; done
     traefik_ip=$(kubectl -n kube-system get svc traefik -o jsonpath='{.spec.clusterIP}')
+    # The host machine's IP, exactly as k3d recorded it for host.k3d.internal
+    # (CoreDNS's NodeHosts file is where that alias lives).
+    host_ip=$(kubectl -n kube-system get cm coredns -o jsonpath='{.data.NodeHosts}' \
+        | awk '$2 == "host.k3d.internal" {print $1}')
+    if [ -z "$host_ip" ]; then
+        echo "host.k3d.internal missing from CoreDNS NodeHosts — is this a k3d cluster?"
+        exit 1
+    fi
     # AAAA answers empty (NODATA) rather than falling through to SERVFAIL, so
     # dual-stack resolvers cleanly fall back to the A record. Note musl-based
     # (Alpine) containers never ask: musl hardcodes *.localhost to loopback.
@@ -124,16 +137,27 @@ cluster-dns:
         template IN AAAA {
             rcode NOERROR
         }
+    }" \
+        --from-literal=syfthub.server="syfthub.localhost:53 {
+        template IN A {
+            answer \"{{{{ .Name }} 60 IN A ${host_ip}\"
+        }
+        template IN AAAA {
+            rcode NOERROR
+        }
     }" --dry-run=client -o yaml | kubectl apply -f -
     kubectl -n kube-system rollout restart deploy/coredns
     kubectl -n kube-system rollout status deploy/coredns --timeout=60s
     echo "In-cluster DNS: *.station.localhost -> ${traefik_ip} (Traefik)"
+    echo "In-cluster DNS: syfthub.localhost   -> ${host_ip} (this host)"
 
 # `up` provisions spaces into k3d over your kubeconfig. Pass your SyftHub
 # email for the admin role; optionally point at a local SyftHub and/or a
 # locally-built syft-space image (built + imported + suggested by onboarding):
 #   just dev up you@org.com
-#   just dev up admin=you@org.com hub=http://localhost:8080 space=dev
+#   just dev up admin=you@org.com hub=http://syfthub.localhost:8080 space=dev
+# syfthub.localhost is the canonical local-hub name — the same URL resolves in
+# browsers, in this host process, AND in space pods (via cluster-dns).
 # `down` tears down the WHOLE dev loop: the k3d cluster AND the host-run
 # station's state (~/.syft-station) — the dev station's DB lives on the host,
 # so a plain `just down` would leave it behind, stale against a fresh cluster.
@@ -236,7 +260,9 @@ ensure-space-image tag:
         just space-image {{tag}}
     fi
 
-# Pass your SyftHub email for the admin role; optionally a different SyftHub:
+# Pass your SyftHub email for the admin role; optionally a different SyftHub
+# (for a host-run local hub, use hub=http://syfthub.localhost:8080 — the one
+# name that resolves in browsers and in pods alike):
 #   just up you@org.com
 #   just up admin=you@org.com hub=https://syfthub.staging.org
 #   just up you@org.com space=mytag   # force-build a local syft-space image

--- a/station/justfile
+++ b/station/justfile
@@ -171,10 +171,16 @@ dev *args="up":
     if [ -z "$admin_email" ]; then
         echo "WARNING: no admin email set — every sign-in gets the member role."
     fi
-    if [ -n "$space_tag" ]; then
+    # Space image: default self-seeds :dev (build only if absent); an explicit
+    # space=TAG forces a rebuild; space=none runs on published images only.
+    if [ "$space_tag" = "none" ]; then
+        :
+    elif [ -n "$space_tag" ]; then
         just space-image "$space_tag"
-        # Onboarding's version picker suggests this tag — no retyping it.
         export SYFT_STATION_SPACE_VERSION="$space_tag"
+    else
+        just ensure-space-image dev
+        export SYFT_STATION_SPACE_VERSION=dev
     fi
     export SYFT_STATION_PROVISIONER=k8s
     export SYFT_STATION_NAMESPACE={{namespace}}
@@ -215,23 +221,59 @@ station-image:
     docker build -t {{station_image}} .
     k3d image import {{station_image}} -c {{cluster_name}}
 
+# Self-seed the syft-space image: build + import only when the tag is missing
+# from the cluster node, so `just dev`/`just up` are complete on a fresh
+# cluster without taxing every warm loop. Forcing a rebuild after syft-space
+# code changes stays explicit: `just space-image dev` (or `space=dev`).
+[private]
+ensure-space-image tag:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if docker exec k3d-{{cluster_name}}-server-0 \
+        crictl images -q ghcr.io/openmined/syft-space:{{tag}} | grep -q .; then
+        echo "syft-space:{{tag}} already on the cluster node."
+    else
+        just space-image {{tag}}
+    fi
+
 # Pass your SyftHub email for the admin role; optionally a different SyftHub:
 #   just up you@org.com
 #   just up admin=you@org.com hub=https://syfthub.staging.org
+#   just up you@org.com space=mytag   # force-build a local syft-space image
+#   just up you@org.com space=none    # published space images only
+
+# One command, everything included — cluster, deps, station image, and the
+# syft-space :dev image (self-seeded when missing, so fresh clusters need no
+# manual import).
 
 # FULL in-cluster: the station pod via Helm (parity with prod).
-up admin="" hub="": ensure-cluster station-image
+up admin="" hub="" space="": ensure-cluster station-image
     #!/usr/bin/env bash
     set -euo pipefail
     admin_email="{{admin}}"; admin_email="${admin_email#admin=}"
     hub_url="{{hub}}"; hub_url="${hub_url#hub=}"
+    space_tag="{{space}}"; space_tag="${space_tag#space=}"
     if [ -z "$admin_email" ]; then
         echo "WARNING: no admin email set — every sign-in gets the member role."
         echo "         Use: just up you@org.com"
     fi
+    # Space image: same policy as `just dev` — default self-seeds :dev,
+    # space=TAG force-rebuilds, space=none skips local images.
+    if [ "$space_tag" = "none" ]; then
+        space_tag=""
+    elif [ -n "$space_tag" ]; then
+        just space-image "$space_tag"
+    else
+        space_tag="dev"
+        just ensure-space-image dev
+    fi
     helm_args=(--set-string station.adminEmail="$admin_email")
     if [ -n "$hub_url" ]; then
         helm_args+=(--set-string station.syfthubUrl="$hub_url")
+    fi
+    if [ -n "$space_tag" ]; then
+        # Onboarding's version picker suggests this tag — no retyping it.
+        helm_args+=(--set-string station.extraEnv.SYFT_STATION_SPACE_VERSION="$space_tag")
     fi
     # One release, station ON — installs the deps and the station together. The
     # chart preserves the session secret across upgrades, so cookies stay valid.
@@ -253,11 +295,13 @@ up admin="" hub="": ensure-cluster station-image
 down:
     k3d cluster delete {{cluster_name}}
 
-# Stop the cluster WITHOUT deleting it: the node containers pause, so PVCs,
-# pulled images, and all in-cluster state survive. Frees CPU/RAM between dev
-# sessions. Resume with `just cluster`, `just dev`, or `just up` — they start
-# a stopped cluster automatically (ensure-cluster) and pick up where it left
-# off, no image re-pulls, no re-onboarding.
+# The node containers pause, so PVCs, pulled images, and all in-cluster state
+# survive — frees CPU/RAM between dev sessions. Resume with `just cluster`,
+# `just dev`, or `just up`: they start a stopped cluster automatically
+# (ensure-cluster) and pick up where it left off, no image re-pulls, no
+# re-onboarding.
+
+# Stop the cluster WITHOUT deleting it (volumes and images kept).
 pause:
     k3d cluster stop {{cluster_name}}
     @echo "Cluster stopped — data and images retained. Resume: just dev | just up"

--- a/station/justfile
+++ b/station/justfile
@@ -129,9 +129,19 @@ cluster-dns:
     until kubectl -n kube-system get svc traefik >/dev/null 2>&1; do sleep 2; done
     traefik_ip=$(kubectl -n kube-system get svc traefik -o jsonpath='{.spec.clusterIP}')
     # The host machine's IP, exactly as k3d recorded it for host.k3d.internal
-    # (CoreDNS's NodeHosts file is where that alias lives).
-    host_ip=$(kubectl -n kube-system get cm coredns -o jsonpath='{.data.NodeHosts}' \
-        | awk '$2 == "host.k3d.internal" {print $1}')
+    # (CoreDNS's NodeHosts file is where that alias lives). k3d injects that
+    # record asynchronously after the API server is up — on a fresh cluster
+    # it can land AFTER Traefik's Service, so poll for it (bounded: a missing
+    # record on a non-k3d cluster should still fail, not hang).
+    echo "Waiting for the host.k3d.internal record..."
+    host_ip=""
+    for _ in $(seq 1 60); do
+        host_ip=$(kubectl -n kube-system get cm coredns \
+            -o jsonpath='{.data.NodeHosts}' 2>/dev/null \
+            | awk '$2 == "host.k3d.internal" {print $1}')
+        [ -n "$host_ip" ] && break
+        sleep 2
+    done
     if [ -z "$host_ip" ]; then
         echo "host.k3d.internal missing from CoreDNS NodeHosts — is this a k3d cluster?"
         exit 1

--- a/station/justfile
+++ b/station/justfile
@@ -9,6 +9,7 @@
 #                                   #   (spaces still provisioned into k3d)
 #   just dev down                   # tear down cluster + host station state
 #   just up  admin=you@org.com      # FULL in-cluster: station pod via Helm
+#   just pause                      # stop the cluster; volumes/images survive
 #   just down                       # tear the cluster down (host state kept)
 #
 # `just dev` is the everyday loop — edit backend code, uvicorn reloads, no
@@ -52,7 +53,15 @@ ensure-cluster: bootstrap
     #!/usr/bin/env bash
     set -euo pipefail
     if k3d cluster list | grep -q "^{{cluster_name}} "; then
-        echo "Cluster '{{cluster_name}}' already exists."
+        # A paused cluster (`just pause`) still lists — start it if its
+        # server count reads 0/1, and it resumes with volumes/images intact.
+        running=$(k3d cluster list {{cluster_name}} --no-headers | awk '{print $2}')
+        if [ "${running%%/*}" = "0" ]; then
+            echo "Cluster '{{cluster_name}}' is stopped — starting it."
+            k3d cluster start {{cluster_name}}
+        else
+            echo "Cluster '{{cluster_name}}' already exists."
+        fi
     else
         k3d cluster create {{cluster_name}} \
             --registry-create {{cluster_name}}-registry:0.0.0.0:5111 \
@@ -243,6 +252,15 @@ up admin="" hub="": ensure-cluster station-image
 # Tear the cluster down (station pod, spaces, and all in-cluster data).
 down:
     k3d cluster delete {{cluster_name}}
+
+# Stop the cluster WITHOUT deleting it: the node containers pause, so PVCs,
+# pulled images, and all in-cluster state survive. Frees CPU/RAM between dev
+# sessions. Resume with `just cluster`, `just dev`, or `just up` — they start
+# a stopped cluster automatically (ensure-cluster) and pick up where it left
+# off, no image re-pulls, no re-onboarding.
+pause:
+    k3d cluster stop {{cluster_name}}
+    @echo "Cluster stopped — data and images retained. Resume: just dev | just up"
 
 # For testing UNPUBLISHED syft-space builds. Normally spaces pull the published
 # image (ghcr.io/openmined/syft-space) at whatever tag the admin picks.

--- a/station/justfile
+++ b/station/justfile
@@ -63,9 +63,20 @@ ensure-cluster: bootstrap
             echo "Cluster '{{cluster_name}}' already exists."
         fi
     else
+        # $HOME lands on the node at /mnt/host-home; spaces mount it read-only
+        # at ~/host-home (spaces.hostMount, on in values-dev). Create-time only.
         k3d cluster create {{cluster_name}} \
             --registry-create {{cluster_name}}-registry:0.0.0.0:5111 \
-            -p "80:80@loadbalancer" -p "443:443@loadbalancer"
+            -p "80:80@loadbalancer" -p "443:443@loadbalancer" \
+            --volume "$HOME:/mnt/host-home@server:0"
+    fi
+    # A cluster born before the $HOME mapping existed can't gain it in place —
+    # spaces would see an empty ~/host-home, so say it loudly instead of silently.
+    if ! docker inspect k3d-{{cluster_name}}-server-0 \
+        --format '{{{{range .Mounts}}{{{{println .Destination}}{{{{end}}' \
+        | grep -qx /mnt/host-home; then
+        echo "WARNING: this cluster predates the host-home mapping — spaces will"
+        echo "         see an EMPTY ~/host-home. Recreate to get it: just down, then re-up."
     fi
     # k3s ships Traefik with ExternalName backends disabled (an SSRF guard for
     # shared clusters, irrelevant here). The chart's dev host-route needs them
@@ -216,6 +227,9 @@ dev *args="up":
     export SYFT_STATION_PUBLIC_URL=http://station.localhost
     # No certs in dev — spaces are minted plain-http URLs.
     export SYFT_STATION_SPACE_SCHEME=http
+    # Spaces see the host's home dir read-only at ~/host-home (the cluster maps
+    # $HOME to the node's /mnt/host-home at creation; off by default in prod).
+    export SYFT_STATION_SPACE_HOST_MOUNT=true
     if [ -n "$hub_url" ]; then
         export SYFT_STATION_SYFTHUB_URL="$hub_url"
     fi


### PR DESCRIPTION
This pull request introduces a new feature to allow mounting the host's home directory into every Syft Space as a read-only volume, improves developer documentation and onboarding, and enhances the provisioning RBAC and wallet setup UX. The most important changes are grouped below.

### Host home directory mount for spaces

* Added the ability to mount the cluster node's `/mnt/host-home` directory into every space, read-only at `/root/host-home`, controlled by the `space_host_mount` setting and Helm chart values (`spaces.hostMount`). This is enabled by default in dev and off in production. The mount is implemented in the backend manifest rendering and exposed in the config. [[1]](diffhunk://#diff-778796f2f1ce6f32b273863d58f50b6dc7d47eb157de6773b04133d10bcabd7cR24-R31) [[2]](diffhunk://#diff-778796f2f1ce6f32b273863d58f50b6dc7d47eb157de6773b04133d10bcabd7cR59) [[3]](diffhunk://#diff-778796f2f1ce6f32b273863d58f50b6dc7d47eb157de6773b04133d10bcabd7cR127-R145) [[4]](diffhunk://#diff-dfbfcf92024e0bcee2158b8e63595b05e983357b7273a636832a3970a6cac4e7R150-R159) [[5]](diffhunk://#diff-b53a7d14c8bbfd86621087132148be5b6a66e0586eb9d7f98b5b93073eee3963R62-R63) [[6]](diffhunk://#diff-7da397afc3c0ed2505b54ecd4a5bbaab069262b88b7d2880a46cb0327244f0eeR36-R38) [[7]](diffhunk://#diff-de956c2500842509b68675afe2dbcf534add73f4358df0df3e43e0acffbfcc57R101-R106)

* Added tests to verify that the host mount is only present when enabled, and that it is correctly configured as read-only and inside the container's home directory. [[1]](diffhunk://#diff-35165cd0057fb296139b695b1da4bde06f3516a8207279f39d8e8e1dd90951e6R145-R175) [[2]](diffhunk://#diff-35165cd0057fb296139b695b1da4bde06f3516a8207279f39d8e8e1dd90951e6R27) [[3]](diffhunk://#diff-3003cd9cbbf295d85f805ce6624513e8466849ab1513c0752c42837443f3c9f1R31)

### Developer documentation and onboarding improvements

* Updated documentation to recommend using `syfthub.localhost` as the canonical local hub domain for consistent resolution in browsers and clusters, and clarified CORS and onboarding flow for local development. [[1]](diffhunk://#diff-ea61a1d5c245a43e41ccfca7d35daf16c9761043aecd04d3288294a9008ebf83L143-R158) [[2]](diffhunk://#diff-dfbfcf92024e0bcee2158b8e63595b05e983357b7273a636832a3970a6cac4e7L56-R59)

* Added a note in the justfile about the new `just pause` command for cluster management.

### Provisioning RBAC enhancements

* Extended Kubernetes RBAC to allow the provisioning logic to list pods and get pod logs, enabling faster and more reliable provisioning status checks.

### Wallet setup and UX improvements

* Enhanced the station setup dialog and wallet form to support replacing an existing wallet, show a summary card for the current wallet, and clarify the replace flow. Added a new `WalletSummaryCard` component for consistent wallet display. [[1]](diffhunk://#diff-b22737e9fdc1f9478ed6cc52891a3b99431dfcc122d3acd3e1ab2d9d5cb8133fR17) [[2]](diffhunk://#diff-b22737e9fdc1f9478ed6cc52891a3b99431dfcc122d3acd3e1ab2d9d5cb8133fL73-R78) [[3]](diffhunk://#diff-b22737e9fdc1f9478ed6cc52891a3b99431dfcc122d3acd3e1ab2d9d5cb8133fR262-R315) [[4]](diffhunk://#diff-1e0a764bdfc120f8818dc0e7f6fb40e313b560b2471d0959036028648403dd64R19) [[5]](diffhunk://#diff-1e0a764bdfc120f8818dc0e7f6fb40e313b560b2471d0959036028648403dd64L32-R52) [[6]](diffhunk://#diff-1e0a764bdfc120f8818dc0e7f6fb40e313b560b2471d0959036028648403dd64R171-R179) [[7]](diffhunk://#diff-71b73b4de758b1e2b98f0269e6e4b3c7ff422492729fb93f48455aa02d9d89c3R1-R25)