### PR TITLE
Normalize email casing and add TLS support for spaces

### DIFF
--- a/station/backend/syft_station/alembic/versions/b13bbb37fe06_lowercase_stored_emails.py
+++ b/station/backend/syft_station/alembic/versions/b13bbb37fe06_lowercase_stored_emails.py
@@ -1,0 +1,70 @@
+"""lowercase stored emails
+
+Revision ID: b13bbb37fe06
+Revises: c3f1a9d40e21
+Create Date: 2026-08-10 15:46:29.528390
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b13bbb37fe06"
+down_revision: str | None = "c3f1a9d40e21"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# Emails are now lowercased at the validation boundary (NormalizedEmail);
+# this brings every already-stored email to the same form so equality
+# comparisons and the email-keyed unique indexes see one identity per
+# account.
+_EMAIL_COLUMNS = [
+    ("space_requests", "owner_email"),
+    ("spaces", "owner_email"),
+    ("invoices", "user_email"),
+    ("user_balances", "user_email"),
+    ("ledger_entries", "user_email"),
+]
+
+# Must stay in sync with OWNER_SLOT_STATUSES in requests/entities.py (same
+# list as the uq_owner_live_request index in c3f1a9d40e21).
+_LIVE_STATUSES = "('pending', 'provisioning', 'active', 'failed')"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Lowercasing must not merge rows a unique index keeps apart — a balance
+    # is money and a live request is a member's one space slot, so neither
+    # may be combined silently. Abort listing the offenders; the operator
+    # resolves them by hand and re-runs.
+    conflicts = []
+    for table, column, where in [
+        ("user_balances", "user_email", ""),
+        ("space_requests", "owner_email", f"WHERE status IN {_LIVE_STATUSES}"),
+    ]:
+        rows = conn.execute(
+            sa.text(
+                f"SELECT group_concat({column}, ', ') FROM {table} {where} "
+                f"GROUP BY lower({column}) HAVING count(DISTINCT {column}) > 1"
+            )
+        ).fetchall()
+        conflicts.extend(f"{table}.{column}: {row[0]}" for row in rows)
+    if conflicts:
+        raise RuntimeError(
+            "These rows differ only by email casing and would collide once "
+            "lowercased — resolve them by hand, then re-run the migration:\n"
+            + "\n".join(conflicts)
+        )
+
+    for table, column in _EMAIL_COLUMNS:
+        conn.execute(sa.text(f"UPDATE {table} SET {column} = lower({column})"))
+
+
+def downgrade() -> None:
+    # The original casing is gone; lowercase emails are valid under every
+    # prior schema, so there is nothing to restore.
+    pass

--- a/station/backend/syft_station/components/auth/handlers.py
+++ b/station/backend/syft_station/components/auth/handlers.py
@@ -34,7 +34,7 @@ class AuthHandler:
         role = (
             ROLE_ADMIN
             if app_settings.admin_email
-            and profile.email.lower() == app_settings.admin_email.lower()
+            and profile.email == app_settings.admin_email.lower()
             else ROLE_MEMBER
         )
         return SessionUser(

--- a/station/backend/syft_station/components/auth/session.py
+++ b/station/backend/syft_station/components/auth/session.py
@@ -12,6 +12,7 @@ from itsdangerous import BadSignature, SignatureExpired, URLSafeTimedSerializer
 from loguru import logger
 from pydantic import BaseModel
 
+from syft_station.components.shared.email import NormalizedEmail
 from syft_station.config import app_settings
 
 # The __Host- prefix binds the cookie to host-only + Secure + Path=/, which
@@ -30,9 +31,13 @@ ROLE_MEMBER = "member"
 
 
 class SessionUser(BaseModel):
-    """The signed session payload."""
+    """The signed session payload.
 
-    email: str
+    The email is normalized at parse time so a cookie minted before emails
+    were lowercased still compares equal to today's stored rows.
+    """
+
+    email: NormalizedEmail
     username: str
     name: str
     role: str

--- a/station/backend/syft_station/components/auth/syfthub.py
+++ b/station/backend/syft_station/components/auth/syfthub.py
@@ -13,6 +13,8 @@ from typing import Any
 import httpx
 from pydantic import BaseModel
 
+from syft_station.components.shared.email import NormalizedEmail
+
 _HTTP_TIMEOUT_SECONDS = 15.0
 
 _GUEST_SUB = "guest"
@@ -35,14 +37,14 @@ class SyftHubProfile(BaseModel):
 
     id: int
     username: str
-    email: str
+    email: NormalizedEmail
     full_name: str
 
 
 class VerifiedBuyer(BaseModel):
     """Claims the station bills on, from ``POST /api/v1/verify``."""
 
-    email: str
+    email: NormalizedEmail
     exp: int | None = None
 
 

--- a/station/backend/syft_station/components/provision/manifests.py
+++ b/station/backend/syft_station/components/provision/manifests.py
@@ -57,6 +57,7 @@ class RenderSettings(Protocol):
     docling_url: str
     managed_by_name: str
     space_host_mount: bool
+    space_tls_secret: str
     syfthub_url: object  # str | pydantic HttpUrl — rendered via str()
 
 
@@ -143,4 +144,14 @@ def render_space_manifests(
         pod["containers"][0]["volumeMounts"].append(
             {"name": "host-home", "mountPath": HOST_MOUNT_PATH, "readOnly": True}
         )
+    # TLS is conditional structure too: with a cert Secret configured (its
+    # certificate must cover this host — spaces share one wildcard cert),
+    # the Ingress terminates TLS; without one it stays plain http.
+    if settings.space_tls_secret:
+        manifests["ingress"]["spec"]["tls"] = [
+            {
+                "hosts": [values["HOST"]],
+                "secretName": settings.space_tls_secret,
+            }
+        ]
     return manifests

--- a/station/backend/syft_station/components/requests/schemas.py
+++ b/station/backend/syft_station/components/requests/schemas.py
@@ -4,7 +4,9 @@ import re
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel, EmailStr, field_validator
+from pydantic import BaseModel, field_validator
+
+from syft_station.components.shared.email import NormalizedEmail
 
 # DNS-1123 label: lowercase alphanumeric + hyphens, no leading/trailing
 # hyphen, ≤63 chars (same rule as the frontend's slugify).
@@ -33,7 +35,7 @@ class SubmitRequestBody(BaseModel):
     subdomain: str
     reason: str = ""
     # Admin only: create the space for this member (ignored for members).
-    owner_email: EmailStr | None = None
+    owner_email: NormalizedEmail | None = None
 
     @field_validator("space_name")
     @classmethod

--- a/station/backend/syft_station/components/shared/email.py
+++ b/station/backend/syft_station/components/shared/email.py
@@ -1,0 +1,14 @@
+"""The one email type for fields that identify an account.
+
+Emails are persisted and compared verbatim everywhere (ownership guards,
+the one-live-request index, balance rows keyed by email), so every email
+must be lowercase before it reaches a handler. This type establishes that
+at the validation boundary; SyftHub normalizes the same way, so lowering
+never conflates two hub accounts.
+"""
+
+from typing import Annotated
+
+from pydantic import AfterValidator, EmailStr
+
+NormalizedEmail = Annotated[EmailStr, AfterValidator(str.lower)]

--- a/station/backend/syft_station/config.py
+++ b/station/backend/syft_station/config.py
@@ -147,6 +147,15 @@ class AppSettings(BaseSettings):
     space_cpu_limit: str = Field(default="1")
     space_memory_request: str = Field(default="512Mi")
     space_memory_limit: str = Field(default="2Gi")
+    space_tls_secret: str = Field(
+        default="",
+        description=(
+            "Name of a kubernetes.io/tls Secret in the spaces' namespace "
+            "whose certificate covers <subdomain>.<domain> (a wildcard SAN); "
+            "each space Ingress terminates TLS with it. Empty renders the "
+            "Ingress without a tls section — plain http."
+        ),
+    )
     space_host_mount: bool = Field(
         default=False,
         description=(

--- a/station/backend/syft_station/k8s/space/ingress.yaml
+++ b/station/backend/syft_station/k8s/space/ingress.yaml
@@ -1,5 +1,6 @@
-# Per-space Ingress — routes https://<subdomain>.<domain> to the space Service.
-# TLS is terminated by the ingress controller / cluster issuer (out of scope here).
+# Per-space Ingress — routes <subdomain>.<domain> to the space Service.
+# A tls section is injected in render_space_manifests when a cert Secret is
+# configured (space_tls_secret); otherwise the space serves plain http.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/station/backend/tests/test_auth.py
+++ b/station/backend/tests/test_auth.py
@@ -97,6 +97,27 @@ async def test_no_admin_email_means_no_admin(monkeypatch):
     assert user.role == ROLE_MEMBER
 
 
+async def test_login_lowercases_profile_email(monkeypatch):
+    monkeypatch.setattr(app_settings, "admin_email", "")
+
+    def hub(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/api/v1/auth/login":
+            return httpx.Response(200, json={"access_token": "tok"})
+        return httpx.Response(
+            200,
+            json={
+                "id": 7,
+                "username": "alice",
+                "email": "Alice@Test.COM",
+                "full_name": "Alice",
+            },
+        )
+
+    handler = AuthHandler(make_hub_client(hub))
+    user = await handler.login("Alice@Test.COM", "pw")
+    assert user.email == "alice@test.com"
+
+
 # ── Credits identity: PAT mint / whoami / buyer-token verification ──────────
 
 
@@ -179,6 +200,16 @@ async def test_verify_buyer_token_returns_billing_claims():
     buyer = await client.verify_buyer_token("syft_pat_abc", "sat-token")
     assert buyer.email == "buyer@test.com"
     assert buyer.exp == 1700000000
+
+
+async def test_verify_buyer_token_lowercases_email():
+    client = make_hub_client(
+        verify_hub(
+            {"valid": True, "sub": "9", "email": "Buyer@Test.COM", "username": "buyer"}
+        )
+    )
+    buyer = await client.verify_buyer_token("syft_pat_abc", "sat-token")
+    assert buyer.email == "buyer@test.com"
 
 
 async def test_verify_buyer_token_invalid_raises_buyer_error():

--- a/station/backend/tests/test_k8s_provisioner.py
+++ b/station/backend/tests/test_k8s_provisioner.py
@@ -29,6 +29,7 @@ SETTINGS = SimpleNamespace(
     docling_url="http://docling-serve:5001",
     managed_by_name="Syft Station",
     space_host_mount=False,
+    space_tls_secret="",
     syfthub_url="https://hub.test",
     provision_timeout_seconds=5,
     provision_poll_interval_seconds=0.01,

--- a/station/backend/tests/test_manifests.py
+++ b/station/backend/tests/test_manifests.py
@@ -25,6 +25,7 @@ SETTINGS = SimpleNamespace(
     docling_url="http://docling-serve:5001",
     managed_by_name="Syft Station",
     space_host_mount=False,
+    space_tls_secret="",
     syfthub_url="https://hub.test/",
 )
 
@@ -171,6 +172,18 @@ def test_host_mount_flag_adds_readonly_hostpath():
         "mountPath": "/root/host-home",
         "readOnly": True,
     }
+
+
+def test_no_ingress_tls_by_default(manifests):
+    assert "tls" not in manifests["ingress"]["spec"]
+
+
+def test_tls_secret_terminates_tls_at_the_space_ingress():
+    settings = SimpleNamespace(**{**vars(SETTINGS), "space_tls_secret": "spaces-tls"})
+    ingress = render_space_manifests(SPEC, settings)["ingress"]
+    assert ingress["spec"]["tls"] == [
+        {"hosts": ["alpha.spaces.test.org"], "secretName": "spaces-tls"}
+    ]
 
 
 def test_deployment_health_probes_hit_the_contract_path(manifests):

--- a/station/backend/tests/test_requests.py
+++ b/station/backend/tests/test_requests.py
@@ -197,6 +197,26 @@ async def test_admin_on_behalf_hits_the_owners_slot(handler):
     assert "bob@test.com" in exc.value.detail
 
 
+async def test_on_behalf_owner_email_is_lowercased(handler):
+    body = SubmitRequestBody(
+        space_name="For Bob", subdomain="for-bob", owner_email="Bob@Test.COM"
+    )
+    request = await handler.submit(body, ADMIN)
+    assert request.owner_email == "bob@test.com"
+
+    # A differently-cased spelling is the same owner — the slot guard sees it.
+    with pytest.raises(HTTPException) as exc:
+        await handler.submit(
+            SubmitRequestBody(
+                space_name="Bob Again",
+                subdomain="bob-again",
+                owner_email="BOB@test.com",
+            ),
+            ADMIN,
+        )
+    assert exc.value.status_code == 409
+
+
 async def test_admins_own_request_does_not_block_on_behalf_submits(handler):
     await handler.submit(submit_body("admins-own"), ADMIN)
 

--- a/station/chart/templates/_helpers.tpl
+++ b/station/chart/templates/_helpers.tpl
@@ -73,3 +73,17 @@ ingress is disabled — endpoints then publish bundles but no buyer URLs.
 {{- printf "%s://%s" $scheme .Values.station.ingress.host -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+The cert Secret every space Ingress terminates TLS with. spaces.tlsSecret
+names it directly; left empty, spaces inherit the station's TLS Secret (one
+multi-SAN cert — station host + space wildcard — is the normal setup, so
+one Secret serves both). Empty result = space Ingresses stay plain http.
+*/}}
+{{- define "syft-station.spaceTlsSecret" -}}
+{{- if .Values.spaces.tlsSecret -}}
+{{- .Values.spaces.tlsSecret -}}
+{{- else if .Values.station.ingress.tls.enabled -}}
+{{- .Values.station.ingress.tls.secretName -}}
+{{- end -}}
+{{- end -}}

--- a/station/chart/templates/station/deployment.yaml
+++ b/station/chart/templates/station/deployment.yaml
@@ -59,6 +59,8 @@ spec:
               value: {{ .Values.spaces.memoryLimit | quote }}
             - name: SYFT_STATION_SPACE_SCHEME
               value: {{ .Values.spaces.scheme | quote }}
+            - name: SYFT_STATION_SPACE_TLS_SECRET
+              value: {{ include "syft-station.spaceTlsSecret" . | quote }}
             - name: SYFT_STATION_SPACE_HOST_MOUNT
               value: {{ .Values.spaces.hostMount | quote }}
             - name: SYFT_STATION_MANAGED_BY_NAME

--- a/station/chart/values.yaml
+++ b/station/chart/values.yaml
@@ -88,8 +88,18 @@ spaces:
   # version picker, never fixed here.
   image: ghcr.io/openmined/syft-space
   # Scheme of the public space URLs the station mints (<scheme>://<sub>.<domain>).
-  # Prod terminates TLS at the ingress; dev has no certs and uses http.
+  # Independent of tlsSecret: TLS may also terminate upstream (a fronting
+  # proxy/CDN) with no in-cluster cert. Dev has no certs and uses http.
   scheme: https
+  # kubernetes.io/tls Secret every space Ingress terminates TLS with. Its
+  # certificate must cover the space names — a wildcard SAN for *.<host>,
+  # or *.<prefix>.<host> if setup picks a subdomain prefix (a cert wildcard
+  # matches exactly one label and never the bare host). Left empty, spaces
+  # inherit station.ingress.tls.secretName: one multi-SAN cert (station host
+  # + space wildcard) in one Secret serves the station and every space. Set
+  # explicitly only when spaces need their own cert. No station TLS either
+  # = space Ingresses stay plain http.
+  tlsSecret: ""
   ingressClass: traefik
   pvcSize: 2Gi
   cpuRequest: 250m

--- a/station/frontend/src/components/SetupStationDialog.vue
+++ b/station/frontend/src/components/SetupStationDialog.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue'
-import { ArrowLeft, ArrowRight, Check, Globe, Rocket, Tag, Wallet } from 'lucide-vue-next'
+import { ArrowLeft, ArrowRight, Check, Globe, Lock, Rocket, Tag, Wallet } from 'lucide-vue-next'
 import { toast } from 'vue-sonner'
 import { Button } from '@/components/ui/button'
 import {
@@ -209,6 +209,14 @@ async function finish() {
             <Globe class="h-3 w-3" />
             Spaces will look like: research-lab.{{ effectiveDomain }}
           </p>
+          <p class="flex items-start gap-1.5 text-xs text-muted-foreground">
+            <Lock class="mt-0.5 h-3 w-3 shrink-0" />
+            <span>
+              For HTTPS, one certificate with two names — <code>{{ stationHost }}</code> and
+              <code>*.{{ effectiveDomain }}</code> — serves the station and every space: a
+              certificate wildcard covers exactly one label, never the bare host.
+            </span>
+          </p>
           <div class="flex items-center justify-between">
             <button
               type="button"
@@ -237,6 +245,14 @@ async function finish() {
           <p class="flex items-center gap-1.5 text-xs text-muted-foreground">
             <Globe class="h-3 w-3" />
             Spaces will look like: research-lab.{{ domainInput.trim() || '…' }}
+          </p>
+          <p class="flex items-start gap-1.5 text-xs text-muted-foreground">
+            <Lock class="mt-0.5 h-3 w-3 shrink-0" />
+            <span>
+              For HTTPS, the spaces' certificate needs a
+              <code>*.{{ domainInput.trim() || 'your-domain' }}</code> wildcard name — a
+              certificate wildcard covers exactly one label.
+            </span>
           </p>
           <div class="flex items-center justify-between">
             <button


### PR DESCRIPTION
This pull request introduces two major improvements: (1) it enforces strict lowercasing and normalization of all stored and handled email addresses throughout the backend, ensuring consistent identity handling and preventing case-related bugs; and (2) it adds support for optional TLS termination at each space's Kubernetes Ingress, including configuration, manifest rendering, and documentation. Comprehensive tests and documentation are included for both features.

**Email normalization and case-insensitive identity handling:**

* Introduced a `NormalizedEmail` type (Pydantic-validated, always lowercase) and replaced all relevant `email` fields and parameters with this type across models, schemas, and handlers, ensuring emails are always stored and compared in lowercase. [[1]](diffhunk://#diff-ee76127e0c4adf34c54e0ea258f362fafd3d6e3a340b91bdb8919337cb62f2e9R1-R14) [[2]](diffhunk://#diff-d8add935fedf016f1eee3f44752202021ebc577ccffdef2cc188f3c38d6e3ff5R15) [[3]](diffhunk://#diff-d8add935fedf016f1eee3f44752202021ebc577ccffdef2cc188f3c38d6e3ff5L33-R40) [[4]](diffhunk://#diff-b0b352d23fa0f8b8e87261c5a67182c9cc6c139dbb90741a53102dd8022d457dR16-R17) [[5]](diffhunk://#diff-b0b352d23fa0f8b8e87261c5a67182c9cc6c139dbb90741a53102dd8022d457dL38-R47) [[6]](diffhunk://#diff-8fc179c739081b542dbd763e063a82effb98d3de93f0dcd9741c095c247616a5L7-R9) [[7]](diffhunk://#diff-8fc179c739081b542dbd763e063a82effb98d3de93f0dcd9741c095c247616a5L36-R38)
* Added a database migration to retroactively lowercase all stored emails, with safety checks to prevent accidental merging of distinct records differing only by case.
* Updated authentication and request handling logic to use normalized emails, and added/updated tests verifying that emails are always lowercased and treated case-insensitively. [[1]](diffhunk://#diff-3a0602413e2aa093b67212d9a06d2590e063de1dbaad3e67ff3e63a39e0d7475L37-R37) [[2]](diffhunk://#diff-7e99eb9dec283264e6ed4155b0d0b70a6a576ac500a0972630422c0f7ed96858R100-R120) [[3]](diffhunk://#diff-7e99eb9dec283264e6ed4155b0d0b70a6a576ac500a0972630422c0f7ed96858R205-R214) [[4]](diffhunk://#diff-524acdea383d0ba301a56721ddd40ad29197a9cb4f2d8ec49a2c39d1180fe2a0R200-R219)

**TLS support for space Ingresses:**

* Added a new `space_tls_secret` configuration option, allowing operators to specify a Kubernetes TLS Secret for per-space Ingress TLS termination; if unset, spaces default to plain HTTP or inherit the station's certificate. [[1]](diffhunk://#diff-dfbfcf92024e0bcee2158b8e63595b05e983357b7273a636832a3970a6cac4e7R150-R158) [[2]](diffhunk://#diff-778796f2f1ce6f32b273863d58f50b6dc7d47eb157de6773b04133d10bcabd7cR60) [[3]](diffhunk://#diff-778796f2f1ce6f32b273863d58f50b6dc7d47eb157de6773b04133d10bcabd7cR147-R156) [[4]](diffhunk://#diff-3003cd9cbbf295d85f805ce6624513e8466849ab1513c0752c42837443f3c9f1R32) [[5]](diffhunk://#diff-35165cd0057fb296139b695b1da4bde06f3516a8207279f39d8e8e1dd90951e6R28) [[6]](diffhunk://#diff-35165cd0057fb296139b695b1da4bde06f3516a8207279f39d8e8e1dd90951e6R177-R188)
* Updated Kubernetes manifest rendering (`render_space_manifests`) and Helm chart templates to conditionally inject the TLS section into space Ingresses based on configuration, and added documentation and UI hints explaining certificate requirements. [[1]](diffhunk://#diff-778796f2f1ce6f32b273863d58f50b6dc7d47eb157de6773b04133d10bcabd7cR147-R156) [[2]](diffhunk://#diff-939e4a5920c19c1702b3f7cae846e6b91c05541b72dae2762a0843120e0c2fe3L1-R3) [[3]](diffhunk://#diff-9d053e99041df5618b17d2cef4d9444959e8addf35e0a3ffa8709bc96906cc4aR76-R89) [[4]](diffhunk://#diff-b53a7d14c8bbfd86621087132148be5b6a66e0586eb9d7f98b5b93073eee3963R62-R63) [[5]](diffhunk://#diff-de956c2500842509b68675afe2dbcf534add73f4358df0df3e43e0acffbfcc57L91-R102) [[6]](diffhunk://#diff-b22737e9fdc1f9478ed6cc52891a3b99431dfcc122d3acd3e1ab2d9d5cb8133fR212-R219) [[7]](diffhunk://#diff-b22737e9fdc1f9478ed6cc52891a3b99431dfcc122d3acd3e1ab2d9d5cb8133fR249-R256)
* Added and updated tests to verify correct TLS configuration in rendered manifests and chart values.

These changes ensure robust, case-insensitive user identity management and provide flexible, secure deployment options for HTTPS in multi-tenant environments.