### PR TITLE
Implement one-button release pipeline for station images and charts

### DIFF
--- a/.github/workflows/station-release.yml
+++ b/.github/workflows/station-release.yml
@@ -1,0 +1,205 @@
+# Syft Station release — one button derives everything.
+#
+# Run from the Actions tab (workflow_dispatch), choosing a bump type. The
+# release job bumps station/backend/pyproject.toml with `uv version` — the
+# version the running station reports at /version — commits it to main, tags
+# the commit station-<version> (a record, not a trigger), and the remaining
+# jobs publish, in lockstep under that one version:
+#   - the station image  ghcr.io/openmined/syft-station:<version> (+ latest),
+#     multi-arch (amd64 + arm64), built from station/Dockerfile — the
+#     frontend compiles inside the image, no separate build step
+#   - the Helm chart     oci://ghcr.io/openmined/charts/syft-station,
+#     packaged from station/chart with version AND appVersion stamped to
+#     <version> at package time — the repo's Chart.yaml stays a placeholder
+#
+# Everything runs in ONE workflow because a tag pushed with the default
+# GITHUB_TOKEN cannot trigger another workflow (GitHub's recursion guard);
+# sequential jobs also mean a failed publish is re-run from the failed job
+# under the same version, never re-bumped.
+#
+# The chart's image tag defaults to appVersion, so installing chart <version>
+# deploys image <version>:
+#   helm install syft-station oci://ghcr.io/openmined/charts/syft-station \
+#     --version <version> --namespace syft-spaces --create-namespace \
+#     --set station.adminEmail=... --set station.ingress.host=...
+name: Station Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump for this release"
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+# One release at a time — a second dispatch queues instead of racing the
+# version commit.
+concurrency:
+  group: station-release
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  release:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+      sha: ${{ steps.bump.outputs.sha }}
+    steps:
+      - name: Refuse to release from anywhere but main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "Releases cut from main only (dispatched from ${{ github.ref }})."
+          exit 1
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Bump the version, commit, and tag
+        id: bump
+        run: |
+          cd station/backend
+          uv version --bump "${{ inputs.bump }}"
+          version=$(uv version --short)
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml uv.lock
+          git commit -m "chore(station): release ${version}"
+          git tag -a "station-${version}" -m "Syft Station ${version}"
+          git push origin HEAD:main "station-${version}"
+
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+  build:
+    timeout-minutes: 30
+    needs: release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout the release commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract platform suffix
+        id: platform
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "suffix=${platform#linux/}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push station image
+        uses: docker/build-push-action@v6
+        with:
+          context: station
+          file: station/Dockerfile
+          push: true
+          platforms: ${{ matrix.platform }}
+          tags: ${{ env.REGISTRY }}/${{ github.repository_owner }}/syft-station:${{ needs.release.outputs.version }}-${{ steps.platform.outputs.suffix }}
+          cache-from: type=gha,scope=station-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=station-${{ matrix.platform }}
+
+  manifest:
+    timeout-minutes: 15
+    needs: [release, build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Create and push multi-arch manifest
+        run: |
+          IMAGE="${{ env.REGISTRY }}/${{ github.repository_owner }}/syft-station"
+          IMAGE="${IMAGE,,}"
+          VERSION="${{ needs.release.outputs.version }}"
+
+          docker buildx imagetools create -t "${IMAGE}:${VERSION}" \
+            "${IMAGE}:${VERSION}-amd64" \
+            "${IMAGE}:${VERSION}-arm64"
+
+          docker buildx imagetools create -t "${IMAGE}:latest" \
+            "${IMAGE}:${VERSION}-amd64" \
+            "${IMAGE}:${VERSION}-arm64"
+
+  chart:
+    timeout-minutes: 10
+    needs: [release, manifest]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout the release commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.release.outputs.sha }}
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Lint chart
+        run: helm lint station/chart
+
+      - name: Package chart at the release version
+        run: |
+          helm package station/chart \
+            --version "${{ needs.release.outputs.version }}" \
+            --app-version "${{ needs.release.outputs.version }}" \
+            --destination dist
+
+      - name: Push chart to GHCR
+        run: |
+          OWNER="${{ github.repository_owner }}"
+          OWNER="${OWNER,,}"
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login "${{ env.REGISTRY }}" \
+              --username "${{ github.actor }}" --password-stdin
+          helm push \
+            "dist/syft-station-${{ needs.release.outputs.version }}.tgz" \
+            "oci://${{ env.REGISTRY }}/${OWNER}/charts"

--- a/.github/workflows/station-release.yml
+++ b/.github/workflows/station-release.yml
@@ -1,27 +1,51 @@
-# Syft Station release — one button derives everything.
+# Syft Station release — one button, one version, everything in lockstep.
 #
-# Run from the Actions tab (workflow_dispatch), choosing a bump type. The
-# release job bumps station/backend/pyproject.toml with `uv version` — the
-# version the running station reports at /version — commits it to main, tags
-# the commit station-<version> (a record, not a trigger), and the remaining
-# jobs publish, in lockstep under that one version:
-#   - the station image  ghcr.io/openmined/syft-station:<version> (+ latest),
-#     multi-arch (amd64 + arm64), built from station/Dockerfile — the
-#     frontend compiles inside the image, no separate build step
-#   - the Helm chart     oci://ghcr.io/openmined/charts/syft-station,
-#     packaged from station/chart with version AND appVersion stamped to
-#     <version> at package time — the repo's Chart.yaml stays a placeholder
+# HOW TO RUN IT
+#   Actions tab → "Station Release" → Run workflow → pick patch / minor / major.
+#   Only runnable from main; a second run queues rather than racing the first.
 #
-# Everything runs in ONE workflow because a tag pushed with the default
-# GITHUB_TOKEN cannot trigger another workflow (GitHub's recursion guard);
-# sequential jobs also mean a failed publish is re-run from the failed job
-# under the same version, never re-bumped.
+# WHAT HAPPENS
 #
-# The chart's image tag defaults to appVersion, so installing chart <version>
-# deploys image <version>:
-#   helm install syft-station oci://ghcr.io/openmined/charts/syft-station \
-#     --version <version> --namespace syft-spaces --create-namespace \
-#     --set station.adminEmail=... --set station.ingress.host=...
+#     ┌───────────────────────────────────────────────────────┐
+#     │ release   bump → <v>, commit to main, tag station-<v> │
+#     └───────────────────────────┬───────────────────────────┘
+#                     ┌───────────┴───────────┐
+#            ┌────────▼────────┐     ┌────────▼────────┐
+#            │ build  amd64    │     │ build  arm64    │
+#            └────────┬────────┘     └────────┬────────┘
+#                     └───────────┬───────────┘
+#                 ┌───────────────▼───────────────┐
+#                 │ manifest  :<v> + :latest      │
+#                 └───────────────┬───────────────┘
+#                 ┌───────────────▼───────────────┐
+#                 │ chart     helm push @ <v>     │
+#                 └───────────────────────────────┘
+#
+# WHAT SHIPS
+#   Version  `uv version --bump` on station/backend/pyproject.toml decides <v>.
+#            This is the version the running station reports at /version.
+#   Image    ghcr.io/openmined/syft-station:<v> (and :latest), amd64 + arm64.
+#            Built from station/Dockerfile — the frontend compiles inside the
+#            image, so there is no separate frontend build step.
+#   Chart    oci://ghcr.io/openmined/charts/syft-station, packaged from
+#            station/chart with version AND appVersion stamped to <v> at
+#            package time (the repo's Chart.yaml stays a placeholder).
+#   Git tag  station-<v> — a record of what shipped, not a trigger.
+#
+# INSTALLING WHAT IT PUBLISHED
+#   The chart's image tag defaults to appVersion, so chart <v> always deploys
+#   image <v>:
+#     helm install syft-station oci://ghcr.io/openmined/charts/syft-station \
+#       --version <v> --namespace syft-spaces --create-namespace \
+#       --set station.adminEmail=... --set station.ingress.host=...
+#
+# IF A JOB FAILS
+#   Re-run from the failed job — the version is already committed and tagged,
+#   so the release is never bumped twice.
+#
+# WHY ONE WORKFLOW
+#   A tag pushed with the default GITHUB_TOKEN cannot trigger another workflow
+#   (GitHub's recursion guard), so publishing has to live in these same jobs.
 name: Station Release
 
 on:
@@ -36,8 +60,7 @@ on:
           - minor
           - major
 
-# One release at a time — a second dispatch queues instead of racing the
-# version commit.
+# One release at a time, so two dispatches can't race the version commit.
 concurrency:
   group: station-release
   cancel-in-progress: false
@@ -46,6 +69,7 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
+  # 1. Decide the version everything else is stamped with.
   release:
     timeout-minutes: 10
     runs-on: ubuntu-latest
@@ -84,6 +108,7 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
           echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+  # 2. One image per architecture, tagged :<v>-amd64 / :<v>-arm64.
   build:
     timeout-minutes: 30
     needs: release
@@ -133,6 +158,7 @@ jobs:
           cache-from: type=gha,scope=station-${{ matrix.platform }}
           cache-to: type=gha,mode=max,scope=station-${{ matrix.platform }}
 
+  # 3. Join the per-arch images into the tags users actually pull.
   manifest:
     timeout-minutes: 15
     needs: [release, build]
@@ -166,6 +192,7 @@ jobs:
             "${IMAGE}:${VERSION}-amd64" \
             "${IMAGE}:${VERSION}-arm64"
 
+  # 4. Publish the chart last, so it never points at an image that isn't there.
   chart:
     timeout-minutes: 10
     needs: [release, manifest]

--- a/station/justfile
+++ b/station/justfile
@@ -24,7 +24,7 @@
 
 cluster_name := "syft-station"
 namespace := "syft-spaces"
-release := "syft-station"
+helm_release := "syft-station"
 chart := "chart"
 dev_values := "chart/values-dev.yaml"
 station_image := "syft-station:dev"
@@ -103,7 +103,7 @@ ensure-cluster: bootstrap
 cluster: ensure-cluster
     #!/usr/bin/env bash
     set -euo pipefail
-    helm upgrade --install {{release}} {{chart}} \
+    helm upgrade --install {{helm_release}} {{chart}} \
         -n {{namespace}} --create-namespace \
         -f {{dev_values}} --set station.enabled=false \
         --wait --timeout {{helm_timeout}}
@@ -327,13 +327,13 @@ up admin="" hub="" space="": ensure-cluster station-image
     fi
     # One release, station ON — installs the deps and the station together. The
     # chart preserves the session secret across upgrades, so cookies stay valid.
-    helm upgrade --install {{release}} {{chart}} \
+    helm upgrade --install {{helm_release}} {{chart}} \
         -n {{namespace}} --create-namespace \
         -f {{dev_values}} "${helm_args[@]}" \
         --wait --timeout {{helm_timeout}}
     # Force a fresh pod even when the :dev tag is unchanged.
-    kubectl -n {{namespace}} rollout restart deploy/{{release}}
-    kubectl -n {{namespace}} rollout status deploy/{{release}} --timeout=180s
+    kubectl -n {{namespace}} rollout restart deploy/{{helm_release}}
+    kubectl -n {{namespace}} rollout status deploy/{{helm_release}} --timeout=180s
     echo ""
     echo "Syft Station is up: http://station.localhost"
     echo "First-run setup domain: station.localhost"
@@ -372,7 +372,7 @@ space-image tag:
 
 # Render the chart with prod values (sanity check before shipping).
 template:
-    helm template {{release}} {{chart}} -n {{namespace}}
+    helm template {{helm_release}} {{chart}} -n {{namespace}}
 
 # Lint the chart (dev + prod values).
 lint-chart:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for releasing Syft Station and updates the `station/justfile` to improve naming consistency for Helm release commands. The workflow automates version bumping, image building (multi-arch), Helm chart packaging, and publishing. The `justfile` changes replace the ambiguous `release` variable with `helm_release` for clarity and consistency.

**New Station Release Workflow:**

* Added `.github/workflows/station-release.yml` to automate the entire Syft Station release process, including version bumping, image build and push (multi-arch), Helm chart packaging, and publishing to GHCR, all triggered via workflow dispatch.

**Justfile variable renaming and usage updates:**

* Renamed `release` variable to `helm_release` in `station/justfile` for clarity and to avoid confusion with other release concepts.
* Updated all Helm and kubectl commands in `station/justfile` to use `helm_release` instead of `release`, ensuring consistent deployment and rollout operations. [[1]](diffhunk://#diff-ebabf0016f78be1bdd03ed2be16ae5503fc45ec48568bfa2df793d3a57a69adaL106-R106) [[2]](diffhunk://#diff-ebabf0016f78be1bdd03ed2be16ae5503fc45ec48568bfa2df793d3a57a69adaL330-R336) [[3]](diffhunk://#diff-ebabf0016f78be1bdd03ed2be16ae5503fc45ec48568bfa2df793d3a57a69adaL375-R375)