### PR TITLE
Fix DNS record restoration and enhance setup dialog functionality

### DIFF
--- a/station/backend/syft_station/components/images/handlers.py
+++ b/station/backend/syft_station/components/images/handlers.py
@@ -30,15 +30,20 @@ class ImageHandler:
         self._expires_at = 0.0
         self._lock = asyncio.Lock()
 
-    async def list_images(self, limit: int) -> list[ImageTagResponse]:
+    async def list_images(
+        self, limit: int, refresh: bool = False
+    ) -> list[ImageTagResponse]:
         """The ``limit`` newest build tags, flagging the one ``latest`` matches.
 
-        Refreshes from the registry when the cache has expired. If a refresh
-        fails but an earlier one succeeded, the stale catalog is served; with
-        nothing cached at all the registry error surfaces as a 502.
+        Refreshes from the registry when the cache has expired — or on
+        ``refresh``, which bypasses the TTL (the per-tag memo makes that
+        cheap: only tags never seen before cost registry requests). If a
+        refresh fails but an earlier one succeeded, the stale catalog is
+        served; with nothing cached at all the registry error surfaces as
+        a 502.
         """
         async with self._lock:
-            if time.monotonic() >= self._expires_at:
+            if refresh or time.monotonic() >= self._expires_at:
                 await self._refresh()
         return [
             ImageTagResponse(

--- a/station/backend/syft_station/components/images/routes.py
+++ b/station/backend/syft_station/components/images/routes.py
@@ -17,10 +17,14 @@ def build_image_routes(handler: ImageHandler) -> APIRouter:
     @router.get("", response_model=list[ImageTagResponse])
     async def list_images(
         limit: int = Query(default=5, ge=1, le=25),
+        refresh: bool = Query(
+            default=False,
+            description="Bypass the catalog TTL — pick up tags pushed moments ago",
+        ),
         user: SessionUser = Depends(require_admin),
         handler: ImageHandler = Depends(get_handler),
     ) -> list[ImageTagResponse]:
         """Newest syft-space image tags from the registry (admin)."""
-        return await handler.list_images(limit)
+        return await handler.list_images(limit, refresh=refresh)
 
     return router

--- a/station/backend/syft_station/main.py
+++ b/station/backend/syft_station/main.py
@@ -1,5 +1,6 @@
 """Main FastAPI application."""
 
+import asyncio
 from contextlib import asynccontextmanager
 from importlib.metadata import version as pkg_version
 from pathlib import Path
@@ -152,7 +153,20 @@ async def lifespan(app: FastAPI):
         except Exception as e:
             logger.error(f"Kubernetes cluster is not reachable at startup: {e}")
 
+    # Warm the image catalog so the first version picker (onboarding hits it
+    # right after boot) finds a cache instead of the cold registry chain.
+    # Fire-and-forget: a failure only means the first UI call pays the cost.
+    async def _warm_image_catalog() -> None:
+        try:
+            await image_handler.list_images(limit=5)
+        except Exception as e:
+            logger.warning(f"Image catalog warmup failed: {e}")
+
+    warmup_task = asyncio.create_task(_warm_image_catalog())
+
     yield
+
+    warmup_task.cancel()
 
     await request_handler.wait_for_provisioning()
     await database.dispose()

--- a/station/backend/tests/test_images.py
+++ b/station/backend/tests/test_images.py
@@ -145,6 +145,18 @@ async def test_second_call_is_served_from_cache():
     assert len(fake.requests) == request_count
 
 
+async def test_refresh_flag_bypasses_the_ttl():
+    fake = FakeRegistry(TAGS)
+    handler = make_handler(fake)
+    await handler.list_images(limit=5)
+    request_count = len(fake.requests)
+
+    # Within the TTL, refresh=True still consults the registry (the tag
+    # list is re-fetched; memoized tags cost no per-tag requests).
+    await handler.list_images(limit=5, refresh=True)
+    assert len(fake.requests) > request_count
+
+
 async def test_expired_refresh_only_resolves_new_tags():
     fake = FakeRegistry(TAGS)
     handler = make_handler(fake)

--- a/station/frontend/src/api/endpoints/images.ts
+++ b/station/frontend/src/api/endpoints/images.ts
@@ -3,5 +3,6 @@ import type { ImageTagResponse } from '@/api/types'
 
 export const imagesApi = {
   /** Admin. Newest syft-space image tags from the registry, for the version picker. */
-  list: (limit = 5): Promise<ImageTagResponse[]> => apiClient.get(`/images?limit=${limit}`),
+  list: (limit = 5, refresh = false): Promise<ImageTagResponse[]> =>
+    apiClient.get(`/images?limit=${limit}${refresh ? '&refresh=true' : ''}`),
 }

--- a/station/frontend/src/components/CreateSpaceDialog.vue
+++ b/station/frontend/src/components/CreateSpaceDialog.vue
@@ -103,11 +103,16 @@ async function create() {
         <div class="grid gap-4 sm:grid-cols-2">
           <div class="space-y-1.5">
             <Label for="create-name">Space name</Label>
-            <Input id="create-name" v-model="spaceName" placeholder="research-lab" />
+            <Input id="create-name" v-model="spaceName" placeholder="e.g. Research Lab" />
           </div>
           <div class="space-y-1.5">
             <Label for="create-subdomain">Subdomain</Label>
-            <Input id="create-subdomain" v-model="subdomain" @input="subdomainEdited = true" />
+            <Input
+              id="create-subdomain"
+              v-model="subdomain"
+              placeholder="research-lab"
+              @input="subdomainEdited = true"
+            />
           </div>
         </div>
         <p class="flex items-center gap-1.5 text-xs text-muted-foreground">

--- a/station/frontend/src/components/RequestForm.vue
+++ b/station/frontend/src/components/RequestForm.vue
@@ -62,7 +62,7 @@ async function submit() {
       <form class="space-y-4" @submit.prevent="submit">
         <div class="space-y-1.5">
           <Label for="space-name">Space name</Label>
-          <Input id="space-name" v-model="spaceName" placeholder="e.g. research-lab" />
+          <Input id="space-name" v-model="spaceName" placeholder="e.g. Research Lab" />
           <p v-if="subdomain" class="flex items-center gap-1.5 text-xs text-muted-foreground">
             <Globe class="h-3 w-3" />
             {{ subdomain }}.{{ station.domain }}

--- a/station/frontend/src/components/SetupStationDialog.vue
+++ b/station/frontend/src/components/SetupStationDialog.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { ArrowLeft, ArrowRight, Check, Globe, Lock, Rocket, Tag, Wallet } from 'lucide-vue-next'
 import { toast } from 'vue-sonner'
 import { Button } from '@/components/ui/button'
@@ -22,9 +22,20 @@ import { useStationStore } from '@/stores/station'
  * First-run setup, shown on the admin dashboard while the domain is not set.
  * Not dismissable — finishing setup (which sets the domain) is what closes it.
  */
-defineProps<{ open: boolean }>()
+const props = defineProps<{ open: boolean }>()
 
 const station = useStationStore()
+
+// Warm the image catalog the moment the wizard opens — the admin spends the
+// domain and wallet steps ahead of the version picker, so by step 3 the
+// list renders instantly. The picker handles (and falls back on) a failure.
+watch(
+  () => props.open,
+  (open) => {
+    if (open) station.loadImageTags().catch(() => {})
+  },
+  { immediate: true },
+)
 
 const STEPS = [
   { title: 'Domain', icon: Globe },

--- a/station/frontend/src/components/SetupStationDialog.vue
+++ b/station/frontend/src/components/SetupStationDialog.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useRouter } from 'vue-router'
 import { ArrowLeft, ArrowRight, Check, Globe, Lock, Rocket, Tag, Wallet } from 'lucide-vue-next'
 import { toast } from 'vue-sonner'
 import { Button } from '@/components/ui/button'
@@ -16,6 +17,7 @@ import VersionSelect from '@/components/VersionSelect.vue'
 import WalletSetupForm from '@/components/WalletSetupForm.vue'
 import WalletSummaryCard from '@/components/WalletSummaryCard.vue'
 import { ApiError } from '@/api/client'
+import { useSessionStore } from '@/stores/session'
 import { useStationStore } from '@/stores/station'
 
 /**
@@ -25,6 +27,16 @@ import { useStationStore } from '@/stores/station'
 const props = defineProps<{ open: boolean }>()
 
 const station = useStationStore()
+const session = useSessionStore()
+const router = useRouter()
+
+// The dialog is not dismissable (setup is what closes it), so it must offer
+// its own way out of the SESSION — otherwise a wrong-account sign-in is
+// trapped behind the overlay with the header's sign-out unreachable.
+function signOut() {
+  session.signOut()
+  router.push({ name: 'signin' })
+}
 
 // Warm the image catalog the moment the wizard opens — the admin spends the
 // domain and wallet steps ahead of the version picker, so by step 3 the
@@ -363,6 +375,19 @@ async function finish() {
           </Button>
         </div>
       </div>
+
+      <!-- Identity escape hatch: setup is mandatory, the session is not. -->
+      <p class="border-t pt-3 text-center text-xs text-muted-foreground">
+        Signed in as <span class="font-medium">{{ session.profile?.email }}</span>
+        · Not you?
+        <button
+          type="button"
+          class="underline underline-offset-2 hover:text-foreground"
+          @click="signOut"
+        >
+          Sign out
+        </button>
+      </p>
     </DialogContent>
   </Dialog>
 </template>

--- a/station/frontend/src/components/VersionSelect.vue
+++ b/station/frontend/src/components/VersionSelect.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue'
-import { PencilLine } from 'lucide-vue-next'
-import { imagesApi } from '@/api/endpoints/images'
+import { PencilLine, RefreshCw } from 'lucide-vue-next'
 import type { ImageTagResponse } from '@/api/types'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -10,32 +9,46 @@ import {
   Select,
   SelectContent,
   SelectItem,
+  SelectSeparator,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { useStationStore } from '@/stores/station'
 
 /**
  * Picker for the syft-space version (image tag), fed by the registry via
- * the backend's image catalog. Falls back to a free-text input when the
- * registry can't be reached — an air-gapped station still works.
+ * the station store's session-cached catalog. The tag currently held by
+ * the model stays pinned at the top — a fetch never displaces it — with
+ * the registry list below a separator. Falls back to a free-text input
+ * when the registry can't be reached — an air-gapped station still works.
  */
 const model = defineModel<string>({ required: true })
 
-const images = ref<ImageTagResponse[]>([])
-const loading = ref(true)
-const manual = ref(false)
+const station = useStationStore()
 
-const options = computed<ImageTagResponse[]>(() => {
-  // Keep the currently configured tag selectable even when it has aged out
-  // of the newest-five list.
-  if (model.value && !images.value.some((i) => i.tag === model.value)) {
-    return [{ tag: model.value, created: '', revision: null, is_latest: false }, ...images.value]
-  }
-  return images.value
+const manual = ref(false)
+const refreshing = ref(false)
+
+/** The model's tag, enriched with registry metadata when the catalog has it. */
+const current = computed<ImageTagResponse | null>(() => {
+  if (!model.value) return null
+  return (
+    station.imageTags.find((i) => i.tag === model.value) ?? {
+      tag: model.value,
+      created: '',
+      revision: null,
+      is_latest: false,
+    }
+  )
 })
 
+/** Registry tags, minus the pinned current one. */
+const fetched = computed<ImageTagResponse[]>(() =>
+  station.imageTags.filter((i) => i.tag !== model.value),
+)
+
 function formatDate(iso: string): string {
-  if (!iso) return 'currently configured'
+  if (!iso) return ''
   return new Date(iso).toLocaleDateString('en-US', {
     month: 'short',
     day: 'numeric',
@@ -43,41 +56,67 @@ function formatDate(iso: string): string {
   })
 }
 
-onMounted(async () => {
+async function load(refresh = false): Promise<void> {
+  refreshing.value = refresh
   try {
-    images.value = await imagesApi.list()
-    // Nothing picked yet: default to the build "latest" points at.
-    if (!model.value && images.value.length > 0) {
-      model.value = (images.value.find((i) => i.is_latest) ?? images.value[0]!).tag
+    await station.loadImageTags(refresh)
+    // Nothing picked yet (first-run setup): default to the build "latest"
+    // points at. Never overrides a tag the model already holds.
+    if (!model.value && station.imageTags.length > 0) {
+      model.value = (station.imageTags.find((i) => i.is_latest) ?? station.imageTags[0]!).tag
     }
   } catch {
     manual.value = true // registry unreachable — type the tag instead
   } finally {
-    loading.value = false
+    refreshing.value = false
   }
-})
+}
+
+onMounted(() => load())
 </script>
 
 <template>
   <Input v-if="manual" v-model="model" placeholder="Image tag, e.g. 2fa954d" class="font-mono" />
 
   <div v-else class="flex items-center gap-1.5">
-    <Select v-model="model" :disabled="loading">
+    <Select v-model="model" :disabled="station.imageTagsLoading && !refreshing">
       <SelectTrigger class="w-full">
-        <SelectValue :placeholder="loading ? 'Loading versions…' : 'Pick a version'" />
+        <SelectValue :placeholder="station.imageTagsLoading ? 'Loading versions…' : 'Pick a version'" />
       </SelectTrigger>
       <SelectContent>
-        <SelectItem v-for="image in options" :key="image.tag" :value="image.tag">
-          <span class="flex items-center gap-2">
-            <span class="font-mono">{{ image.tag }}</span>
+        <template v-if="current">
+          <SelectItem :value="current.tag">
+            <span class="font-mono">{{ current.tag }}</span>
+            <template #trailing>
+              <span v-if="current.created" class="text-xs text-muted-foreground">
+                {{ formatDate(current.created) }}
+              </span>
+              <Badge variant="outline" class="h-4 px-1.5 text-[10px]">current</Badge>
+            </template>
+          </SelectItem>
+          <SelectSeparator v-if="fetched.length" class="h-0 border-t border-dashed bg-transparent" />
+        </template>
+        <SelectItem v-for="image in fetched" :key="image.tag" :value="image.tag">
+          <span class="font-mono">{{ image.tag }}</span>
+          <template #trailing>
             <span class="text-xs text-muted-foreground">{{ formatDate(image.created) }}</span>
             <Badge v-if="image.is_latest" variant="secondary" class="h-4 px-1.5 text-[10px]">
               latest
             </Badge>
-          </span>
+          </template>
         </SelectItem>
       </SelectContent>
     </Select>
+    <Button
+      variant="ghost"
+      size="icon"
+      class="h-9 w-9 shrink-0"
+      title="Re-check the registry for new tags"
+      :disabled="refreshing"
+      @click="load(true)"
+    >
+      <RefreshCw class="h-3.5 w-3.5" :class="refreshing ? 'animate-spin' : ''" />
+    </Button>
     <Button
       variant="ghost"
       size="icon"

--- a/station/frontend/src/components/ui/select/SelectItem.vue
+++ b/station/frontend/src/components/ui/select/SelectItem.vue
@@ -33,5 +33,9 @@ const forwardedProps = useForwardProps(delegatedProps)
     <SelectItemText>
       <slot />
     </SelectItemText>
+    <!-- Rendered in the dropdown only: SelectItemText is what the closed
+         trigger mirrors, so trailing decorations (dates, badges) must live
+         outside it or they concatenate into the selected-value display. -->
+    <slot name="trailing" />
   </SelectItem>
 </template>

--- a/station/frontend/src/pages/AdminPage.vue
+++ b/station/frontend/src/pages/AdminPage.vue
@@ -70,6 +70,9 @@ const router = useRouter()
 
 onMounted(() => {
   station.loadSetup().catch(() => toast.error('Could not load the station setup'))
+  // Warm the image catalog so the Settings version picker opens instantly;
+  // the picker itself handles (and falls back on) a failure.
+  station.loadImageTags().catch(() => {})
   station.loadRequests().catch(() => toast.error('Could not load requests'))
   station.loadSpaces().catch(() => toast.error('Could not load spaces'))
   // Wallet presence drives the approve dialog's picker + "space includes".
@@ -239,6 +242,15 @@ async function updateOne(space: Space) {
 
 // ---- Settings ----
 const versionInput = ref('')
+// The picker starts from the CURRENT supported version — seeded when setup
+// arrives (async), never overwriting anything the admin already typed.
+watch(
+  () => station.supportedVersion,
+  (v) => {
+    if (v && !versionInput.value) versionInput.value = v
+  },
+  { immediate: true },
+)
 const savingVersion = ref(false)
 
 async function saveVersion() {

--- a/station/frontend/src/stores/station.ts
+++ b/station/frontend/src/stores/station.ts
@@ -1,11 +1,13 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import { creditsApi } from '@/api/endpoints/credits'
+import { imagesApi } from '@/api/endpoints/images'
 import { requestsApi } from '@/api/endpoints/requests'
 import { setupApi } from '@/api/endpoints/setup'
 import { spacesApi } from '@/api/endpoints/spaces'
 import type {
   EarningsResponse,
+  ImageTagResponse,
   MemberEarningsResponse,
   OutstandingBalanceResponse,
   RequestResponse,
@@ -55,6 +57,36 @@ export const useStationStore = defineStore('station', () => {
   const onboarded = computed(() => domain.value !== '')
   /** True once the backend's setup has been fetched (gates the setup dialog). */
   const setupLoaded = ref(false)
+
+  // ---- Image catalog (server-backed, cached for the session) ----
+
+  /** Newest syft-space image tags, shared by every version picker. */
+  const imageTags = ref<ImageTagResponse[]>([])
+  const imageTagsLoaded = ref(false)
+  const imageTagsLoading = ref(false)
+  let imageTagsInflight: Promise<void> | null = null
+
+  /**
+   * Fetch the image catalog once per session; later callers get the cached
+   * list instantly. `refresh` forces a registry round-trip (bypassing the
+   * backend's TTL too) — the picker's refresh button. Throws on failure so
+   * the picker can fall back to manual tag entry.
+   */
+  async function loadImageTags(refresh = false): Promise<void> {
+    if (imageTagsLoaded.value && !refresh) return
+    if (imageTagsInflight && !refresh) return imageTagsInflight
+    imageTagsLoading.value = true
+    imageTagsInflight = (async () => {
+      try {
+        imageTags.value = await imagesApi.list(5, refresh)
+        imageTagsLoaded.value = true
+      } finally {
+        imageTagsLoading.value = false
+        imageTagsInflight = null
+      }
+    })()
+    return imageTagsInflight
+  }
 
   // ---- Setup (server-backed) ----
 
@@ -561,6 +593,9 @@ export const useStationStore = defineStore('station', () => {
     stationHost,
     onboarded,
     setupLoaded,
+    imageTags,
+    imageTagsLoading,
+    loadImageTags,
     loadSetup,
     completeOnboarding,
     pendingCount,

--- a/station/justfile
+++ b/station/justfile
@@ -78,6 +78,33 @@ ensure-cluster: bootstrap
         echo "WARNING: this cluster predates the host-home mapping — spaces will"
         echo "         see an EMPTY ~/host-home. Recreate to get it: just down, then re-up."
     fi
+    # The API can be dead while the containers sit "Up": k3s occasionally
+    # loses a bootstrap race (its cloud-controller-manager exits on RBAC the
+    # apiserver hasn't created yet) and shuts itself down, leaving kubectl
+    # with EOF. Wait for readiness; if the cluster is wedged, restart it
+    # through k3d once — a fresh k3s bootstrap normally wins the race.
+    api_ready() { kubectl get --raw /readyz >/dev/null 2>&1; }
+    echo "Waiting for the Kubernetes API..."
+    ready=""
+    for _ in $(seq 1 20); do
+        if api_ready; then ready=1; break; fi
+        sleep 3
+    done
+    if [ -z "$ready" ]; then
+        echo "API is not responding — restarting the cluster to retry the k3s bootstrap..."
+        k3d cluster stop {{cluster_name}}
+        k3d cluster start {{cluster_name}}
+        for _ in $(seq 1 40); do
+            if api_ready; then ready=1; break; fi
+            sleep 3
+        done
+    fi
+    if [ -z "$ready" ]; then
+        echo "Kubernetes API still unreachable after a restart. Inspect with:"
+        echo "  docker logs k3d-{{cluster_name}}-server-0 | tail -50"
+        echo "or recreate: just down, then re-up."
+        exit 1
+    fi
     # k3s ships Traefik with ExternalName backends disabled (an SSRF guard for
     # shared clusters, irrelevant here). The chart's dev host-route needs them
     # to proxy station.localhost to the host-run station. k3s's helm controller

--- a/station/justfile
+++ b/station/justfile
@@ -128,14 +128,16 @@ cluster-dns:
     echo "Waiting for Traefik..."
     until kubectl -n kube-system get svc traefik >/dev/null 2>&1; do sleep 2; done
     traefik_ip=$(kubectl -n kube-system get svc traefik -o jsonpath='{.spec.clusterIP}')
-    # The host machine's IP, exactly as k3d recorded it for host.k3d.internal
-    # (CoreDNS's NodeHosts file is where that alias lives). k3d injects that
-    # record asynchronously after the API server is up — on a fresh cluster
-    # it can land AFTER Traefik's Service, so poll for it (bounded: a missing
-    # record on a non-k3d cluster should still fail, not hang).
+    # The host machine's IP, as k3d records it for host.k3d.internal in
+    # CoreDNS's NodeHosts. The record can be absent two ways: on a fresh
+    # cluster k3d injects it asynchronously (it can land after Traefik's
+    # Service), and k3s REGENERATES NodeHosts from Node objects whenever it
+    # restarts — so a Docker restart outside `k3d cluster start` wipes the
+    # record and k3d never re-adds it. Poll briefly for k3d's injection,
+    # then re-derive the IP from Docker and put the record back ourselves.
     echo "Waiting for the host.k3d.internal record..."
     host_ip=""
-    for _ in $(seq 1 60); do
+    for _ in $(seq 1 10); do
         host_ip=$(kubectl -n kube-system get cm coredns \
             -o jsonpath='{.data.NodeHosts}' 2>/dev/null \
             | awk '$2 == "host.k3d.internal" {print $1}')
@@ -143,8 +145,24 @@ cluster-dns:
         sleep 2
     done
     if [ -z "$host_ip" ]; then
-        echo "host.k3d.internal missing from CoreDNS NodeHosts — is this a k3d cluster?"
-        exit 1
+        echo "Record missing (a Docker restart outside k3d wipes it) — re-deriving..."
+        # Docker Desktop: host.docker.internal resolves on the cluster network.
+        host_ip=$(docker run --rm --network k3d-{{cluster_name}} alpine:3 \
+            getent ahostsv4 host.docker.internal 2>/dev/null | awk 'NR==1 {print $1}')
+        if [ -z "$host_ip" ]; then
+            # Linux dockerd has no host.docker.internal — the bridge gateway is the host.
+            host_ip=$(docker network inspect k3d-{{cluster_name}} \
+                --format '{{{{(index .IPAM.Config 0).Gateway}}' 2>/dev/null)
+        fi
+        if [ -z "$host_ip" ]; then
+            echo "Could not derive the host IP — is this a k3d cluster?"
+            exit 1
+        fi
+        hosts=$(kubectl -n kube-system get cm coredns -o jsonpath='{.data.NodeHosts}')
+        kubectl -n kube-system patch cm coredns --type merge -p \
+            "$(printf '%s\n%s host.k3d.internal' "$hosts" "$host_ip" \
+               | awk 'BEGIN {printf "{\"data\":{\"NodeHosts\":\""} {printf "%s\\n", $0} END {printf "\"}}"}')"
+        echo "Restored: $host_ip host.k3d.internal"
     fi
     # AAAA answers empty (NODATA) rather than falling through to SERVFAIL, so
     # dual-stack resolvers cleanly fall back to the A record. Note musl-based


### PR DESCRIPTION
This pull request introduces significant improvements to how syft-space image tags (versions) are fetched, cached, and selected throughout the application. The backend now supports explicit cache bypassing for the image catalog, and the frontend introduces a session-wide shared cache, instant version picker loading, and a manual refresh option. The version picker UI is also enhanced for clarity and usability. Additionally, onboarding and admin flows are improved to ensure the version list is always ready and to provide a way to sign out during setup.

**Backend: Image Catalog Refresh and Warmup**
- Added a `refresh` parameter to the backend's `list_images` endpoint and handler, allowing clients to bypass the cache TTL and force a fresh registry fetch. This makes it possible to immediately see newly pushed tags without waiting for cache expiry. [[1]](diffhunk://#diff-5710f6312652824942b983dfe7a35054ebe870cc6b9eb65337df1af335d4131bL33-R46) [[2]](diffhunk://#diff-f5f740023b908b6df1c608993a97bfda0b056a9270dd46dad70ac94bbc50db85R20-R28)
- On application startup, the backend now "warms" the image catalog asynchronously, so the first UI request finds a primed cache instead of incurring registry latency.
- Added a test to ensure the new `refresh` flag bypasses the cache as intended.

**Frontend: Shared Image Tag Cache and Picker Enhancements**
- Introduced a session-scoped image tag cache in the `station` store, with methods to load and refresh the catalog. All version pickers now share this cache, ensuring instant loading after the first fetch and reducing redundant backend requests. [[1]](diffhunk://#diff-3cd12173b9d1a606bae0d792996854fb56242e3613b61cf59e59028a226a9fa0R61-R90) [[2]](diffhunk://#diff-3cd12173b9d1a606bae0d792996854fb56242e3613b61cf59e59028a226a9fa0R596-R598)
- The version picker (`VersionSelect.vue`) now:
  - Pins the currently selected version at the top, even if it's not in the latest list.
  - Separates the current version visually from the fetched list.
  - Provides a manual refresh button to re-fetch tags from the registry.
  - Falls back to manual entry if the registry is unreachable.
  [[1]](diffhunk://#diff-85c0d0e4b50b098372f03d3a2810f8d2ed57cb97b257f84656e258d03af44d51L3-R3) [[2]](diffhunk://#diff-85c0d0e4b50b098372f03d3a2810f8d2ed57cb97b257f84656e258d03af44d51R12-R119)

**Onboarding and Admin UX Improvements**
- The setup dialog preloads the image catalog as soon as it opens, ensuring the version picker step is always instant.
- Added a "Sign out" option to the setup dialog, allowing users to exit the session if they're signed in with the wrong account.
- The admin page also preloads the image catalog to ensure instant picker access in settings.
- The version picker in settings now seeds its value from the current supported version, but never overwrites user input.

**API and UI Consistency**
- Updated the frontend API client to support the new `refresh` parameter for image tag listing.
- Improved placeholder text and input hints in creation and request forms for clarity. [[1]](diffhunk://#diff-3d56d555b08be8c8443d410ddc9533a06218cbdd416b098b3ecbe21001f15397L106-R115) [[2]](diffhunk://#diff-91f97c364f350499939c5f179d26c3e0252fd9fab49048a7df65a2addb9e6fa0L65-R65)
- Updated the select item UI to allow trailing decorations (dates, badges) to display only in the dropdown, not in the trigger.

These changes collectively make version selection faster, more reliable, and more user-friendly across the application.