### PR TITLE
Implement real-time log viewer for admin and owner in spaces

### DIFF
--- a/station/backend/syft_station/components/provision/interfaces.py
+++ b/station/backend/syft_station/components/provision/interfaces.py
@@ -105,3 +105,8 @@ class Provisioner(Protocol):
     async def get_status(self, subdomain: str) -> SpaceRuntimeStatus:
         """Read the space's live running state from the substrate."""
         ...
+
+    async def logs(self, subdomain: str, tail_lines: int) -> str:
+        """The space container's last ``tail_lines`` log lines (a snapshot,
+        newest last). Empty string when the space has no running pod."""
+        ...

--- a/station/backend/syft_station/components/provision/k8s.py
+++ b/station/backend/syft_station/components/provision/k8s.py
@@ -55,6 +55,9 @@ _DEADLINE_CAP_FACTOR = 3
 _CRASH_LOG_LINES = 5
 _CRASH_LOG_MAX_CHARS = 300
 
+# The space's application container (k8s/space/deployment.yaml).
+SPACE_CONTAINER = "syft-space"
+
 # Pod-template annotation bumped to trigger a rolling restart.
 _RESTARTED_AT_ANNOTATION = "syftcluster.openmined.org/restartedAt"
 
@@ -174,7 +177,35 @@ class K8sProvisioner:
         """Read the space's live running state from its Deployment."""
         return await asyncio.to_thread(self._read_status, subdomain)
 
+    async def logs(self, subdomain: str, tail_lines: int) -> str:
+        """Snapshot of the space container's last ``tail_lines`` lines."""
+        return await asyncio.to_thread(self._read_logs, subdomain, tail_lines)
+
     # ── Sync helpers (run via to_thread) ─────────────────────────────────────
+
+    def _read_logs(self, subdomain: str, tail_lines: int) -> str:
+        """Tail the newest live pod's syft-space container (empty if none)."""
+        result = self.kube.core.list_namespaced_pod(
+            self.settings.namespace,
+            label_selector=f"{LABEL_SPACE}={subdomain}",
+        )
+        live = [p for p in result.items or [] if not p.metadata.deletion_timestamp]
+        if not live:
+            return ""
+        pod = max(live, key=lambda p: p.metadata.creation_timestamp or _EPOCH)
+        # _preload_content=False returns the raw HTTPResponse; decoding its
+        # bytes ourselves yields real newlines. (Letting the client
+        # "deserialize" a str hands back the repr of the bytes — one giant
+        # line with literal \n.) No timestamps=True: syft-space already
+        # prefixes its own timestamp, so the kubelet's would double up.
+        resp = self.kube.core.read_namespaced_pod_log(
+            pod.metadata.name,
+            self.settings.namespace,
+            container=SPACE_CONTAINER,
+            tail_lines=tail_lines,
+            _preload_content=False,
+        )
+        return resp.data.decode("utf-8", errors="replace")
 
     def _apply_bundle(self, manifests: dict[str, dict]) -> None:
         ns = self.settings.namespace

--- a/station/backend/syft_station/components/provision/mock.py
+++ b/station/backend/syft_station/components/provision/mock.py
@@ -55,3 +55,15 @@ class MockProvisioner:
         if subdomain in self._paused:
             return SpaceRuntimeStatus.PAUSED
         return SpaceRuntimeStatus.RUNNING
+
+    async def logs(self, subdomain: str, tail_lines: int) -> str:
+        """A few canned lines so the log viewer has something to show without
+        a cluster; empty while paused, like a pod that isn't running."""
+        if subdomain in self._paused:
+            return ""
+        sample = [
+            "2026-08-11T10:00:00Z INFO   uvicorn      Application startup complete",
+            f"2026-08-11T10:00:01Z INFO   syft         space '{subdomain}' ready",
+            "2026-08-11T10:00:12Z INFO   uvicorn      GET /api/v1/health 200 2ms",
+        ]
+        return "\n".join(sample[-tail_lines:])

--- a/station/backend/syft_station/components/spaces/handlers.py
+++ b/station/backend/syft_station/components/spaces/handlers.py
@@ -19,6 +19,7 @@ from syft_station.components.spaces.repository import (
 )
 from syft_station.components.spaces.schemas import (
     AdminUrlResponse,
+    SpaceLogsResponse,
     SpaceResponse,
     SpaceStatusResponse,
     SpaceUpdateResult,
@@ -75,6 +76,21 @@ class SpaceHandler:
                 detail="Could not read the space status",
             ) from e
         return SpaceStatusResponse(status=str(status_))
+
+    async def logs(
+        self, space_id: UUID, user: SessionUser, tail_lines: int
+    ) -> SpaceLogsResponse:
+        """A snapshot tail of the space's logs (admin or the space's owner)."""
+        space = await self._get_owned_space(space_id, user)
+        try:
+            text = await self.provisioner.logs(space.subdomain, tail_lines)
+        except Exception as e:
+            logger.exception(f"Log read failed for '{space.subdomain}'")
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Could not read the space logs",
+            ) from e
+        return SpaceLogsResponse(lines=text.splitlines())
 
     async def pause(self, space_id: UUID, user: SessionUser) -> SpaceStatusResponse:
         """Free the space's compute; its data volume is kept."""

--- a/station/backend/syft_station/components/spaces/routes.py
+++ b/station/backend/syft_station/components/spaces/routes.py
@@ -2,7 +2,7 @@
 
 from uuid import UUID
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 
 from syft_station.components.auth.session import (
     SessionUser,
@@ -12,6 +12,7 @@ from syft_station.components.auth.session import (
 from syft_station.components.spaces.handlers import SpaceHandler
 from syft_station.components.spaces.schemas import (
     AdminUrlResponse,
+    SpaceLogsResponse,
     SpaceResponse,
     SpaceStatusResponse,
     UpdateAllResponse,
@@ -49,6 +50,16 @@ def build_space_routes(handler: SpaceHandler) -> APIRouter:
     ) -> SpaceStatusResponse:
         """Live running/paused/unavailable status, read from Kubernetes."""
         return await handler.runtime_status(space_id, user)
+
+    @router.get("/{space_id}/logs", response_model=SpaceLogsResponse)
+    async def space_logs(
+        space_id: UUID,
+        tail_lines: int = Query(default=200, ge=1, le=1000),
+        user: SessionUser = Depends(get_current_user),
+        handler: SpaceHandler = Depends(get_handler),
+    ) -> SpaceLogsResponse:
+        """Snapshot tail of the space's logs (admin or the space's owner)."""
+        return await handler.logs(space_id, user, tail_lines)
 
     @router.post("/{space_id}/pause", response_model=SpaceStatusResponse)
     async def pause_space(

--- a/station/backend/syft_station/components/spaces/schemas.py
+++ b/station/backend/syft_station/components/spaces/schemas.py
@@ -32,6 +32,15 @@ class SpaceStatusResponse(BaseModel):
     status: str
 
 
+class SpaceLogsResponse(BaseModel):
+    """A snapshot of the space container's recent log lines (newest last).
+
+    Empty when the space has no running pod (paused or not yet up).
+    """
+
+    lines: list[str]
+
+
 class SpaceUpdateResult(BaseModel):
     """One space's outcome in an update sweep."""
 

--- a/station/backend/tests/test_spaces_and_setup.py
+++ b/station/backend/tests/test_spaces_and_setup.py
@@ -216,6 +216,32 @@ async def test_admin_can_pause_any_space(space_handler, space_repository):
     assert paused.status == "paused"
 
 
+async def test_logs_returns_snapshot_lines(space_handler, space_repository):
+    space = await make_space(space_repository, MEMBER.email)
+    result = await space_handler.logs(space.id, MEMBER, tail_lines=200)
+    assert result.lines and all(isinstance(ln, str) for ln in result.lines)
+
+
+async def test_logs_denied_for_non_owner(space_handler, space_repository):
+    space = await make_space(space_repository, MEMBER.email)
+    with pytest.raises(HTTPException) as exc:
+        await space_handler.logs(space.id, OTHER_MEMBER, tail_lines=200)
+    assert exc.value.status_code == 403
+
+
+async def test_admin_can_read_any_space_logs(space_handler, space_repository):
+    space = await make_space(space_repository, MEMBER.email)
+    result = await space_handler.logs(space.id, ADMIN, tail_lines=200)
+    assert result.lines
+
+
+async def test_logs_empty_when_paused(space_handler, space_repository):
+    space = await make_space(space_repository, MEMBER.email)
+    await space_handler.pause(space.id, MEMBER)
+    result = await space_handler.logs(space.id, MEMBER, tail_lines=200)
+    assert result.lines == []
+
+
 async def test_status_unknown_space_404(space_handler):
     from uuid import uuid4
 

--- a/station/frontend/src/api/endpoints/spaces.ts
+++ b/station/frontend/src/api/endpoints/spaces.ts
@@ -1,6 +1,7 @@
 import { apiClient } from '@/api/client'
 import type {
   AdminUrlResponse,
+  SpaceLogsResponse,
   SpaceResponse,
   SpaceStatusResponse,
   UpdateAllResponse,
@@ -15,6 +16,10 @@ export const spacesApi = {
 
   /** Live running/paused/unavailable status, read from Kubernetes. */
   status: (id: string): Promise<SpaceStatusResponse> => apiClient.get(`/spaces/${id}/status`),
+
+  /** Snapshot tail of the space's logs (admin or the space's owner). */
+  logs: (id: string, tailLines = 200): Promise<SpaceLogsResponse> =>
+    apiClient.get(`/spaces/${id}/logs?tail_lines=${tailLines}`),
 
   /** Free the space's compute; data is kept. */
   pause: (id: string): Promise<SpaceStatusResponse> => apiClient.post(`/spaces/${id}/pause`),

--- a/station/frontend/src/api/types/index.ts
+++ b/station/frontend/src/api/types/index.ts
@@ -109,6 +109,10 @@ export interface SpaceStatusResponse {
   status: SpaceRuntimeStatus
 }
 
+export interface SpaceLogsResponse {
+  lines: string[]
+}
+
 /** The space URL with the admin key attached as authToken. */
 export interface AdminUrlResponse {
   url: string

--- a/station/frontend/src/components/ViewLogsSheet.vue
+++ b/station/frontend/src/components/ViewLogsSheet.vue
@@ -1,6 +1,17 @@
 <script setup lang="ts">
-import { nextTick, onUnmounted, ref, watch } from 'vue'
-import { PauseCircle, ScrollText } from 'lucide-vue-next'
+import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import {
+  Check,
+  Copy,
+  Maximize2,
+  Minimize2,
+  Pause,
+  PauseCircle,
+  Play,
+  RefreshCw,
+  ScrollText,
+  WrapText,
+} from 'lucide-vue-next'
 import {
   Sheet,
   SheetContent,
@@ -9,6 +20,9 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet'
 import HealthBadge from '@/components/HealthBadge.vue'
+import { Button } from '@/components/ui/button'
+import { spacesApi } from '@/api/endpoints/spaces'
+import { ApiError } from '@/api/client'
 import type { Space } from '@/lib/types'
 
 const props = defineProps<{
@@ -18,134 +32,252 @@ const props = defineProps<{
 
 const emit = defineEmits<{ 'update:open': [value: boolean] }>()
 
-// TODO: everything below fabricates a plausible log tail — the station has
-// no log endpoint yet. Replace seedLines/liveLine with a real stream (e.g.
-// read_namespaced_pod_log via the backend) when it lands.
+const POLL_MS = 3000
+
+// A snapshot of the pod's last N log lines (GET /spaces/{id}/logs). "Follow"
+// re-fetches that snapshot every few seconds — a bounded poll, not a live
+// stream — replacing the tail each time. `live` = follow mode is on.
 const lines = ref<string[]>([])
+const loading = ref(false)
+const error = ref('')
+const live = ref(false)
+const wrap = ref(true)
+const expanded = ref(false)
+const copied = ref(false)
+const updatedAt = ref(0)
+const now = ref(0)
 const logBox = ref<HTMLElement | null>(null)
-let timer: ReturnType<typeof setInterval> | undefined
 
-function stamp(offsetSeconds = 0): string {
-  return new Date(Date.now() - offsetSeconds * 1000).toISOString().replace('T', ' ').slice(0, 19)
+let pollTimer: ReturnType<typeof setInterval> | undefined
+let clockTimer: ReturnType<typeof setInterval> | undefined
+
+const paused = computed(() => props.space?.health === 'paused')
+
+const updatedAgo = computed(() => {
+  if (!updatedAt.value) return ''
+  const s = Math.max(0, Math.round((now.value - updatedAt.value) / 1000))
+  return s < 2 ? 'just now' : `${s}s ago`
+})
+
+/** A log line split into its (dim) timestamp and level-colored remainder. */
+function parse(line: string): { time: string; rest: string; level: string } {
+  const m = line.match(/^(\d{4}-\d\d-\d\d[ T]\d\d:\d\d:\d\d(?:\.\d+)?Z?)\s*(.*)$/)
+  const time = m ? m[1]! : ''
+  const rest = m ? m[2]! : line
+  const lv = rest.match(/\b(CRITICAL|ERROR|WARNING|WARN|DEBUG|INFO)\b/)
+  return { time, rest, level: lv ? lv[1]! : '' }
 }
 
-function slugOf(space: Space): string {
-  return space.url.replace('https://', '').split('.')[0] ?? space.name
+function levelClass(level: string): string {
+  if (level === 'ERROR' || level === 'CRITICAL') return 'text-red-300'
+  if (level === 'WARNING' || level === 'WARN') return 'text-yellow-200'
+  if (level === 'DEBUG') return 'opacity-60'
+  return ''
 }
 
-/** Startup tail every pod shows, oldest first. */
-function seedLines(space: Space): string[] {
-  const slug = slugOf(space)
-  const seeded: [number, string][] = [
-    [95, 'INFO   uvicorn      Started server process [1]'],
-    [94, `INFO   syft         syft-space v${space.version} starting (mode: cluster)`],
-    [93, `INFO   syft.vector  connected to shared ChromaDB (database: ${slug})`],
-    [92, 'INFO   syft.docling using remote docling-serve'],
-  ]
-  seeded.push([90, 'INFO   uvicorn      Application startup complete'])
-  seeded.push([45, 'INFO   syft.hub     heartbeat ok (next in 60s)'])
-  seeded.push([12, 'INFO   uvicorn      GET /healthcheck 200 2ms'])
-  if (space.health === 'unhealthy') {
-    seeded.push([8, 'ERROR  syft.vector  connection to chroma-shared:8000 timed out (attempt 3)'])
-    seeded.push([4, 'WARN   readiness    probe failed (3/3) — pod marked unready'])
-  }
-  return seeded.map(([ago, msg]) => `${stamp(ago)}  ${msg}`)
+function atBottom(): boolean {
+  const el = logBox.value
+  if (!el) return true
+  return el.scrollHeight - el.scrollTop - el.clientHeight < 40
 }
 
-const HEALTHY_POOL = [
-  'INFO   uvicorn      GET /healthcheck 200 2ms',
-  'INFO   syft.query   answered query for kim@labmate.org (top_k=8, 412ms)',
-  'INFO   syft.ingest  chunked report-q3.pdf → 182 chunks (docling remote)',
-  'DEBUG  chromadb     upserted 182 vectors',
-  'INFO   syft.hub     heartbeat ok (next in 60s)',
-  'INFO   uvicorn      POST /api/v1/query 200 388ms',
-]
-
-const UNHEALTHY_POOL = [
-  'ERROR  syft.vector  connection to chroma-shared:8000 timed out (retrying)',
-  'WARN   readiness    probe failed — pod marked unready',
-  'INFO   uvicorn      GET /healthcheck 503 1ms',
-]
-
-function appendLine() {
+async function load() {
   if (!props.space) return
-  const pool = props.space.health === 'unhealthy' ? UNHEALTHY_POOL : HEALTHY_POOL
-  const line = pool[Math.floor(Math.random() * pool.length)]
-  lines.value.push(`${stamp()}  ${line}`)
-  if (lines.value.length > 200) lines.value.shift()
-  void nextTick(() => {
-    if (logBox.value) logBox.value.scrollTop = logBox.value.scrollHeight
-  })
+  const stick = atBottom()
+  loading.value = true
+  error.value = ''
+  try {
+    const res = await spacesApi.logs(props.space.id)
+    lines.value = res.lines
+    updatedAt.value = Date.now()
+    now.value = Date.now()
+    if (stick) {
+      void nextTick(() => {
+        if (logBox.value) logBox.value.scrollTop = logBox.value.scrollHeight
+      })
+    }
+  } catch (e) {
+    error.value = e instanceof ApiError ? e.message : 'Could not read the logs'
+    lines.value = []
+    live.value = false
+  } finally {
+    loading.value = false
+  }
 }
 
-function stopStream() {
-  if (timer) clearInterval(timer)
-  timer = undefined
+function stopPoll() {
+  if (pollTimer) clearInterval(pollTimer)
+  pollTimer = undefined
+}
+
+watch(live, (on) => {
+  stopPoll()
+  if (on) {
+    void load()
+    pollTimer = setInterval(load, POLL_MS)
+  }
+})
+
+async function copyLogs() {
+  try {
+    await navigator.clipboard.writeText(lines.value.join('\n'))
+    copied.value = true
+    setTimeout(() => (copied.value = false), 1500)
+  } catch {
+    /* clipboard blocked — no-op */
+  }
 }
 
 watch(
   () => props.open,
   (isOpen) => {
-    stopStream()
-    if (isOpen && props.space && props.space.health !== 'paused') {
-      lines.value = seedLines(props.space)
-      timer = setInterval(appendLine, 1800)
-      void nextTick(() => {
-        if (logBox.value) logBox.value.scrollTop = logBox.value.scrollHeight
-      })
+    stopPoll()
+    if (clockTimer) clearInterval(clockTimer)
+    live.value = false
+    if (isOpen && props.space && !paused.value) {
+      void load()
+      clockTimer = setInterval(() => (now.value = Date.now()), 1000)
     } else {
       lines.value = []
+      error.value = ''
     }
   },
 )
 
-onUnmounted(stopStream)
+onUnmounted(() => {
+  stopPoll()
+  if (clockTimer) clearInterval(clockTimer)
+})
 </script>
 
 <template>
   <Sheet :open="open" @update:open="(v: boolean) => emit('update:open', v)">
-    <SheetContent side="right" class="flex w-full flex-col gap-0 sm:max-w-2xl">
-      <SheetHeader v-if="space">
-        <SheetTitle class="flex items-center gap-2">
-          <ScrollText class="h-4 w-4" />
+    <SheetContent
+      side="right"
+      class="flex w-full flex-col gap-0 p-0 transition-[max-width] duration-200"
+      :class="expanded ? 'sm:max-w-5xl' : 'sm:max-w-2xl'"
+    >
+      <SheetHeader v-if="space" class="px-4 pt-4 pb-3">
+        <SheetTitle class="flex items-center gap-2 pr-8">
+          <ScrollText class="h-4 w-4 shrink-0" />
           Logs — {{ space.name }}
           <HealthBadge :health="space.health" />
         </SheetTitle>
         <SheetDescription>
-          Live logs from your space. Shown while it runs — not stored.
+          A snapshot of the space's most recent logs, read live from the pod — not stored.
         </SheetDescription>
       </SheetHeader>
 
-      <div v-if="space" class="min-h-0 flex-1 px-4 pb-4">
+      <!-- Control toolbar -->
+      <div
+        v-if="space && !paused"
+        class="flex items-center gap-1 border-y bg-muted/30 px-3 py-1.5"
+      >
+        <Button
+          :variant="live ? 'secondary' : 'ghost'"
+          size="sm"
+          class="h-7 gap-1.5"
+          @click="live = !live"
+        >
+          <span
+            v-if="live"
+            class="h-1.5 w-1.5 animate-pulse rounded-full bg-success"
+          />
+          <component :is="live ? Pause : Play" v-else class="h-3.5 w-3.5" />
+          {{ live ? 'Following' : 'Follow' }}
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="h-7 gap-1.5"
+          title="Refresh"
+          :disabled="live || loading"
+          @click="load"
+        >
+          <RefreshCw class="h-3.5 w-3.5" :class="loading ? 'animate-spin' : ''" />
+          Refresh
+        </Button>
+        <div class="mx-1 h-4 w-px bg-border" />
+        <Button
+          :variant="wrap ? 'secondary' : 'ghost'"
+          size="sm"
+          class="h-7 gap-1.5"
+          title="Wrap long lines"
+          @click="wrap = !wrap"
+        >
+          <WrapText class="h-3.5 w-3.5" />
+          Wrap
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          class="h-7 gap-1.5"
+          title="Copy all"
+          @click="copyLogs"
+        >
+          <component :is="copied ? Check : Copy" class="h-3.5 w-3.5" />
+          {{ copied ? 'Copied' : 'Copy' }}
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          class="ml-auto h-7 w-7"
+          :title="expanded ? 'Collapse' : 'Expand'"
+          @click="expanded = !expanded"
+        >
+          <component :is="expanded ? Minimize2 : Maximize2" class="h-3.5 w-3.5" />
+        </Button>
+      </div>
+
+      <!-- Body -->
+      <div v-if="space" class="min-h-0 flex-1 px-4 py-3">
         <div
-          v-if="space.health === 'paused'"
+          v-if="paused"
           class="flex h-full flex-col items-center justify-center gap-2 rounded-md border border-dashed text-center text-sm text-muted-foreground"
         >
           <PauseCircle class="h-6 w-6" />
           <p class="font-medium text-foreground">Space is paused — no logs to show</p>
           <p class="max-w-xs text-xs">
-            Logs are available while the space is running. Start the space to stream them again.
+            Logs are available while the space is running. Start the space to read them again.
           </p>
         </div>
 
         <div
           v-else
           ref="logBox"
-          class="h-full overflow-y-auto rounded-md bg-foreground/95 p-3 font-mono text-[11px] leading-relaxed text-background"
+          class="h-full overflow-auto rounded-md bg-foreground/95 p-3 font-mono text-[11px] leading-relaxed text-background"
         >
+          <p v-if="error" class="text-red-300">{{ error }}</p>
+          <p v-else-if="loading && !lines.length" class="text-background/60">Loading logs…</p>
+          <p v-else-if="!lines.length" class="text-background/60">No logs yet.</p>
           <div
             v-for="(line, i) in lines"
             :key="i"
-            class="whitespace-pre-wrap"
-            :class="{
-              'text-red-300': line.includes('ERROR'),
-              'text-yellow-200': line.includes('WARN'),
-              'opacity-70': line.includes('DEBUG'),
-            }"
+            :class="[
+              wrap ? 'whitespace-pre-wrap break-all' : 'whitespace-pre',
+              levelClass(parse(line).level),
+            ]"
           >
-            {{ line }}
+            <template v-if="parse(line).time">
+              <span class="text-background/40">{{ parse(line).time }}</span>
+              {{ ' ' + parse(line).rest }}
+            </template>
+            <template v-else>{{ line }}</template>
           </div>
         </div>
+      </div>
+
+      <!-- Status footer -->
+      <div
+        v-if="space && !paused"
+        class="flex items-center gap-2 border-t px-4 py-1.5 text-xs text-muted-foreground"
+      >
+        <span v-if="live" class="flex items-center gap-1.5">
+          <span class="h-1.5 w-1.5 animate-pulse rounded-full bg-success" />
+          following
+        </span>
+        <span>{{ lines.length }} line{{ lines.length === 1 ? '' : 's' }}</span>
+        <span v-if="updatedAgo" class="ml-auto">updated {{ updatedAgo }}</span>
       </div>
     </SheetContent>
   </Sheet>


### PR DESCRIPTION
This pull request introduces a new API endpoint and supporting backend/frontend logic to allow users (admins or space owners) to fetch and view the latest log lines from a space's container. The implementation includes backend support for Kubernetes, mock environments, API schemas, route handling, and frontend API integration, as well as tests for permissions and behavior.

**Backend: Space Logs API Implementation**

* Added an async `logs` method to the provisioner interface and implemented it for both Kubernetes and mock backends, allowing retrieval of the latest log lines from a space's container (`syft-space`). [[1]](diffhunk://#diff-508212a68fe2373a212f4f64870591c2cf0952077033dc0c7f5c503ccb496db4R108-R112) [[2]](diffhunk://#diff-6cd4ae5942e1baab97c32112f1eafed9bfb6910d46ad9d62fdaa860a26369a5dR58-R60) [[3]](diffhunk://#diff-6cd4ae5942e1baab97c32112f1eafed9bfb6910d46ad9d62fdaa860a26369a5dR180-R209) [[4]](diffhunk://#diff-bc46d2685b67b533c142be569346094324b56319ab6a9c47b20dae194daaa7d4R58-R69)
* Introduced a new `SpaceLogsResponse` schema and corresponding handler method to return logs as a list of strings. Added a `/spaces/{space_id}/logs` route with appropriate query parameters and permissions. [[1]](diffhunk://#diff-6c65fa43a6b3a6dab20f9aa4ec90780dae0a8f01e4a41a383be0d46f1cb661f8R22) [[2]](diffhunk://#diff-6c65fa43a6b3a6dab20f9aa4ec90780dae0a8f01e4a41a383be0d46f1cb661f8R80-R94) [[3]](diffhunk://#diff-307123511468e4f98d3359943b88be7e883b3cfd3dde025d51106e1c447a9656L5-R5) [[4]](diffhunk://#diff-307123511468e4f98d3359943b88be7e883b3cfd3dde025d51106e1c447a9656R15) [[5]](diffhunk://#diff-307123511468e4f98d3359943b88be7e883b3cfd3dde025d51106e1c447a9656R54-R63) [[6]](diffhunk://#diff-02a998d98a720bed5f71ba96a98bde51bf6534d4f74f53741d1dca7c9aac39b7R35-R43)

**Frontend: API and Type Support**

* Added TypeScript types and API client methods for fetching space logs, supporting the new backend endpoint. [[1]](diffhunk://#diff-2372700fb3debec13deff8a3fc990195aa5610136f93020d3820cff47822ffc0R4) [[2]](diffhunk://#diff-2372700fb3debec13deff8a3fc990195aa5610136f93020d3820cff47822ffc0R20-R23) [[3]](diffhunk://#diff-4ac64ea79ddb2558c62086332bce0a7c5e2e0374b1df2490d3dc63a04b9652efR112-R115)
* Updated the `ViewLogsSheet.vue` component to import and prepare for the new log viewing functionality. [[1]](diffhunk://#diff-3c3eace54caf7f7e254b41141cf812c49f9fe55aa2fd564780cf1e2a5b7bc369L2-R14) [[2]](diffhunk://#diff-3c3eace54caf7f7e254b41141cf812c49f9fe55aa2fd564780cf1e2a5b7bc369R23-R25)

**Testing: Permissions and Behavior**

* Added tests to verify that only admins or space owners can access logs, that logs are empty when a space is paused, and that the log snapshot returns lines as expected.