### PR TITLE
fix(ci): repoint frontend build + helm chart paths to packages/ layout

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,10 +40,10 @@ jobs:
           bun-version: latest
 
       - name: Install frontend dependencies
-        run: bun install --cwd frontend
+        run: bun install --cwd packages/spaces/frontend
 
       - name: Build frontend
-        run: bun run --cwd frontend build
+        run: bun run --cwd packages/spaces/frontend build
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/station-release.yml
+++ b/.github/workflows/station-release.yml
@@ -22,13 +22,13 @@
 #                 └───────────────────────────────┘
 #
 # WHAT SHIPS
-#   Version  `uv version --bump` on station/backend/pyproject.toml decides <v>.
+#   Version  `uv version --bump` on packages/station/backend/pyproject.toml decides <v>.
 #            This is the version the running station reports at /version.
 #   Image    ghcr.io/openmined/syft-station:<v> (and :latest), amd64 + arm64.
-#            Built from station/Dockerfile — the frontend compiles inside the
-#            image, so there is no separate frontend build step.
+#            Built from packages/station/Dockerfile — the frontend compiles inside
+#            the image, so there is no separate frontend build step.
 #   Chart    oci://ghcr.io/openmined/charts/syft-station, packaged from
-#            station/chart with version AND appVersion stamped to <v> at
+#            packages/station/chart with version AND appVersion stamped to <v> at
 #            package time (the repo's Chart.yaml stays a placeholder).
 #   Git tag  station-<v> — a record of what shipped, not a trigger.
 #
@@ -214,11 +214,11 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Lint chart
-        run: helm lint station/chart
+        run: helm lint packages/station/chart
 
       - name: Package chart at the release version
         run: |
-          helm package station/chart \
+          helm package packages/station/chart \
             --version "${{ needs.release.outputs.version }}" \
             --app-version "${{ needs.release.outputs.version }}" \
             --destination dist


### PR DESCRIPTION
## Why

Two release workflows were missed in the `packages/` restructure ([#224](https://github.com/OpenMined/syft-space/pull/224)). Both are `workflow_dispatch` (manual), so PR CI never ran them and the bad paths slipped through — they'd only fail on the next real release.

## What

- **`docker-publish.yml`** — build the frontend at `packages/spaces/frontend` (was `frontend/`). Without this the pre-build step fails, `frontend/dist` is never produced, and the image's `COPY frontend/dist ./frontend/dist` errors with `"/frontend/dist": not found` — the exact failure seen in the E2E logs.
- **`station-release.yml`** — `helm lint` / `helm package` now target `packages/station/chart` (was `station/chart`); doc-header paths updated to match.

Verified with a full sweep: no stale non-`packages/` paths remain in any workflow.

## Note on E2E

The E2E red check on the #224 merge commit was a *separate* issue (the test repo referenced old syft-space paths) — already fixed by [`syft-nsai-tests#9`](https://github.com/OpenMined/syft-nsai-tests/pull/9), and E2E on that repo's `main` is green again. Re-running the stale check on the merge commit will clear it.