### PR TITLE
Enhance metadata handling and unify source field names

### DIFF
--- a/packages/spaces/backend/syft_space/components/chunking/chunker.py
+++ b/packages/spaces/backend/syft_space/components/chunking/chunker.py
@@ -11,6 +11,7 @@ funnel into the same extraction + chunking helpers here, so they
 produce identical chunks.
 """
 
+import hashlib
 import logging
 import shutil
 import threading
@@ -234,6 +235,17 @@ def _resolve_backend() -> DoclingBackend:
     return LocalDoclingBackend()
 
 
+def derive_doc_id(external_id: str) -> str:
+    """Stable document id for a source item.
+
+    Derived rather than random so re-ingesting an edited item overwrites its
+    chunks instead of adding a second copy, and so a tombstoned item's vectors
+    can still be found from its external_id alone. Sixteen lowercase hex
+    characters, which is the shape the image route already validates.
+    """
+    return hashlib.sha256(external_id.encode()).hexdigest()[:16]
+
+
 class DocumentChunker:
     """Shared docling conversion + HybridChunker pipeline for all dataset types.
 
@@ -327,7 +339,7 @@ class DocumentChunker:
                 file_size: size in bytes
         """
         ext = Path(file.filename).suffix.lower()
-        doc_id = uuid4().hex[:16]
+        doc_id = derive_doc_id(file.external_id)
 
         # Simple text files - no docling overhead needed
         if ext in [".json", ".txt"]:
@@ -347,6 +359,10 @@ class DocumentChunker:
             ]
 
         images_dir = self.get_page_images_dir(collection_name, doc_id)
+        # doc_id is stable across re-ingests, so last time's pictures would
+        # otherwise pile up beside the new ones under the same directory.
+        if images_dir.exists():
+            shutil.rmtree(images_dir, ignore_errors=True)
 
         def get_chunker():
             return self._get_chunker(tabular=ext in _TABULAR_EXTS)

--- a/packages/spaces/backend/syft_space/components/shared/ingest_types.py
+++ b/packages/spaces/backend/syft_space/components/shared/ingest_types.py
@@ -23,6 +23,14 @@ class IngestContext(Context):
 class IngestFile(BaseModel):
     """Framework-agnostic file wrapper for ingestion."""
 
+    external_id: str = Field(
+        ...,
+        description=(
+            "Source-unique id of the item. The document id stored in the "
+            "vector store derives from it, so re-ingesting replaces the "
+            "previous version instead of adding a second copy."
+        ),
+    )
     path: Path = Field(..., description="Local readable path")
     filename: str = Field(..., description="Display filename")
     file_size: int | None = Field(default=None, description="Size in bytes")

--- a/packages/spaces/backend/syft_space/components/shared/timestamps.py
+++ b/packages/spaces/backend/syft_space/components/shared/timestamps.py
@@ -1,0 +1,39 @@
+"""Parsing of the date formats sources receive from upstream APIs.
+
+Sources put a ``datetime`` in ``IngestFile.metadata`` rather than the raw
+string they were given; the vector store decides how to serialize it.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+
+
+def parse_datetime(value: str | None) -> datetime | None:
+    """Parse an upstream date into an aware UTC ``datetime``.
+
+    Covers ISO 8601 (Atom, Blogger, the WordPress ``*_gmt`` fields) and
+    RFC 822 (RSS ``pubDate``). Returns ``None`` for anything unparseable —
+    a missing date is not worth failing an ingest over.
+
+    A naive value is read as UTC, which is what the formats that omit an
+    offset mean. Letting it default to the machine's local zone would shift
+    every such date by the server's offset.
+    """
+    if not value:
+        return None
+
+    parsed: datetime | None = None
+    for parser in (datetime.fromisoformat, parsedate_to_datetime):
+        try:
+            parsed = parser(value)
+            break
+        except (ValueError, TypeError):
+            continue
+
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)

--- a/packages/spaces/backend/syft_space/components/sources/blogspot/blogspot_source.py
+++ b/packages/spaces/backend/syft_space/components/sources/blogspot/blogspot_source.py
@@ -567,7 +567,7 @@ class BlogspotSource:
                     # fingerprint above still uses the raw `updated`.
                     "updated": parse_datetime(updated),
                     "published": parse_datetime(post.get("published")),
-                    "labels": post.get("labels"),
+                    "tags": post.get("labels"),
                     "author": (post.get("author") or {}).get("displayName"),
                 },
             )

--- a/packages/spaces/backend/syft_space/components/sources/blogspot/blogspot_source.py
+++ b/packages/spaces/backend/syft_space/components/sources/blogspot/blogspot_source.py
@@ -53,6 +53,7 @@ import httpx
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from syft_space.components.shared.ingest_types import IngestFile
+from syft_space.components.shared.timestamps import parse_datetime
 from syft_space.components.shared.utils import ConfigSchemaGenerator
 from syft_space.components.sources.errors import (
     SourceAuthError,
@@ -561,8 +562,11 @@ class BlogspotSource:
                     "post_id": post_id,
                     "title": title,
                     "url": post.get("url"),
-                    "updated": updated,
-                    "published": post.get("published"),
+                    # Datetimes, not raw strings: the vector store turns each
+                    # into an ISO value plus a filterable epoch int. The
+                    # fingerprint above still uses the raw `updated`.
+                    "updated": parse_datetime(updated),
+                    "published": parse_datetime(post.get("published")),
                     "labels": post.get("labels"),
                     "author": (post.get("author") or {}).get("displayName"),
                 },

--- a/packages/spaces/backend/syft_space/components/sources/blogspot/blogspot_source.py
+++ b/packages/spaces/backend/syft_space/components/sources/blogspot/blogspot_source.py
@@ -553,6 +553,7 @@ class BlogspotSource:
         tmp_path.write_text(body, encoding="utf-8")
         try:
             yield IngestFile(
+                external_id=external_id,
                 path=tmp_path,
                 filename=filename,
                 file_size=tmp_path.stat().st_size,

--- a/packages/spaces/backend/syft_space/components/sources/local_file/local_file_source.py
+++ b/packages/spaces/backend/syft_space/components/sources/local_file/local_file_source.py
@@ -209,6 +209,7 @@ class LocalFileSource:
         path = SyncPath(external_id)
         stat = path.stat()
         yield IngestFile(
+            external_id=external_id,
             path=path,
             filename=path.name,
             file_size=stat.st_size,

--- a/packages/spaces/backend/syft_space/components/sources/local_file/local_file_source.py
+++ b/packages/spaces/backend/syft_space/components/sources/local_file/local_file_source.py
@@ -212,7 +212,11 @@ class LocalFileSource:
             path=path,
             filename=path.name,
             file_size=stat.st_size,
-            metadata={"source": LocalFileProvider.NAME, "absolute_path": str(path)},
+            metadata={
+                "source": LocalFileProvider.NAME,
+                "updated": datetime.fromtimestamp(stat.st_mtime, tz=timezone.utc),
+                "absolute_path": str(path),
+            },
         )
 
     def fingerprint(self, external_id: str) -> str:

--- a/packages/spaces/backend/syft_space/components/sources/wordpress/wordpress_source.py
+++ b/packages/spaces/backend/syft_space/components/sources/wordpress/wordpress_source.py
@@ -437,6 +437,7 @@ class WordPressSource:
         tmp_path.write_text(html, encoding="utf-8")
         try:
             yield IngestFile(
+                external_id=external_id,
                 path=tmp_path,
                 filename=f"{slug}.html",
                 file_size=tmp_path.stat().st_size,

--- a/packages/spaces/backend/syft_space/components/sources/wordpress/wordpress_source.py
+++ b/packages/spaces/backend/syft_space/components/sources/wordpress/wordpress_source.py
@@ -32,6 +32,7 @@ import httpx
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from syft_space.components.shared.ingest_types import IngestFile
+from syft_space.components.shared.timestamps import parse_datetime
 from syft_space.components.shared.utils import ConfigSchemaGenerator
 from syft_space.components.sources.errors import (
     SourceAuthError,
@@ -431,7 +432,9 @@ class WordPressSource:
                     "slug": slug,
                     "title": title,
                     "link": post.get("link"),
-                    "modified_gmt": modified_gmt,
+                    # A datetime, not the raw string: the vector store turns
+                    # it into an ISO value plus a filterable epoch int.
+                    "modified_gmt": parse_datetime(modified_gmt),
                     "status": post.get("status"),
                     "categories": post.get("categories"),
                     "tags": post.get("tags"),

--- a/packages/spaces/backend/syft_space/components/sources/wordpress/wordpress_source.py
+++ b/packages/spaces/backend/syft_space/components/sources/wordpress/wordpress_source.py
@@ -242,6 +242,18 @@ async def _validate_connection(cfg: WordPressBrowseConfig) -> None:
             )
 
 
+def _embedded_author(post: dict[str, Any]) -> str | None:
+    """Display name from ``_embed=author``; the bare field is a numeric id."""
+    authors = (post.get("_embedded") or {}).get("author") or []
+    return authors[0].get("name") if authors else None
+
+
+def _embedded_terms(post: dict[str, Any]) -> list[str]:
+    """Category and tag names from ``_embed=wp:term``, which returns ids."""
+    groups = (post.get("_embedded") or {}).get("wp:term") or []
+    return [t["name"] for group in groups for t in group if t.get("name")]
+
+
 def _to_source_item(post_type: str, parent_id: str, item: dict[str, Any]) -> SourceItem:
     """Map a REST listing row to a leaf ``SourceItem`` for the picker."""
     rendered = (item.get("title") or {}).get("rendered")
@@ -398,9 +410,12 @@ class WordPressSource:
             r = await client.get(
                 f"/{rest_base}/{post_id}",
                 params={
+                    # _embed resolves the author and term names in this same
+                    # request; _links must be in _fields for it to apply.
+                    "_embed": "author,wp:term",
                     "_fields": (
-                        "id,slug,link,modified_gmt,title,content,excerpt,"
-                        "categories,tags,author,status"
+                        "id,slug,link,date_gmt,modified_gmt,title,content,"
+                        "excerpt,categories,tags,author,status,_links,_embedded"
                     ),
                 },
             )
@@ -427,18 +442,21 @@ class WordPressSource:
                 file_size=tmp_path.stat().st_size,
                 metadata={
                     "source": WordPressProvider.NAME,
+                    "title": title,
+                    "url": post.get("link"),
+                    "author": _embedded_author(post),
+                    # Datetimes, not raw strings: the vector store turns each
+                    # into an ISO value plus a filterable epoch int.
+                    "published": parse_datetime(post.get("date_gmt")),
+                    "updated": parse_datetime(modified_gmt),
+                    # Categories and tags are both topical labels; the
+                    # canonical field flattens them.
+                    "tags": _embedded_terms(post),
                     "post_type": post_type,
                     "post_id": post_id,
                     "slug": slug,
-                    "title": title,
-                    "link": post.get("link"),
-                    # A datetime, not the raw string: the vector store turns
-                    # it into an ISO value plus a filterable epoch int.
-                    "modified_gmt": parse_datetime(modified_gmt),
                     "status": post.get("status"),
-                    "categories": post.get("categories"),
-                    "tags": post.get("tags"),
-                    "author": post.get("author"),
+                    "author_id": post.get("author"),
                 },
             )
         finally:

--- a/packages/spaces/backend/syft_space/components/vector_stores/chromadb_local/chromadb_vector_store.py
+++ b/packages/spaces/backend/syft_space/components/vector_stores/chromadb_local/chromadb_vector_store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from datetime import datetime, timezone
 from functools import lru_cache
 from types import ModuleType
 from typing import Any
@@ -97,6 +98,31 @@ def _resolve_provisioner_cls() -> type[BaseVectorStoreProvisioner]:
     if app_settings.chromadb_provision:
         return LocalChromaDBProvisioner
     return ExternalChromaDBProvisioner
+
+
+def _chroma_scalars(metadata: dict[str, Any]) -> dict[str, Any]:
+    """Coerce source metadata into the scalar types ChromaDB accepts.
+
+    ChromaDB stores only str/int/float/bool, so lists are joined and None is
+    dropped. A datetime becomes both an ISO string and a ``{key}_ts`` epoch
+    int — metadata filtering compares numbers, so the int is what makes a
+    date range queryable.
+    """
+    scalars: dict[str, Any] = {}
+    for key, value in metadata.items():
+        if value is None:
+            continue
+        if isinstance(value, datetime):
+            aware = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
+            scalars[key] = aware.astimezone(timezone.utc).isoformat()
+            scalars[f"{key}_ts"] = int(aware.timestamp())
+        elif isinstance(value, str | int | float | bool):
+            scalars[key] = value
+        elif isinstance(value, list | tuple | set):
+            scalars[key] = ",".join(str(v) for v in value if v is not None)
+        else:
+            scalars[key] = str(value)
+    return scalars
 
 
 class ChromaDBLocalVectorStore:
@@ -241,13 +267,17 @@ class ChromaDBLocalVectorStore:
                 file,
                 self.collection_name,
             )
-            await self._store_chunks(collection, chunks)
+            await self._store_chunks(collection, chunks, file.metadata)
 
-    async def _store_chunks(self, collection, chunks: list[dict]) -> None:
+    async def _store_chunks(
+        self, collection, chunks: list[dict], source_metadata: dict | None = None
+    ) -> None:
         """Embed and store chunks with neighbor references in ChromaDB.
 
         Each chunk gets prev/next pointers so the search method can
-        fetch surrounding context in a single batch call.
+        fetch surrounding context in a single batch call, plus whatever the
+        source recorded about the item — publication date, author, link —
+        which search returns to the caller alongside the text.
         """
 
         # Early return if no chunks to store.
@@ -264,9 +294,11 @@ class ChromaDBLocalVectorStore:
             self._generate_embeddings, [chunk["embedding_text"] for chunk in chunks]
         )
 
-        # Build metadata for all chunks.
+        # Source metadata first: the structural keys below must win a clash.
+        extra = _chroma_scalars(source_metadata or {})
         metadatas = [
             {
+                **extra,
                 "doc_id": doc_id,
                 "chunk_index": i,
                 "prev_chunk_id": chunk_ids[i - 1] if i > 0 else "",

--- a/packages/spaces/backend/syft_space/components/vector_stores/chromadb_local/chromadb_vector_store.py
+++ b/packages/spaces/backend/syft_space/components/vector_stores/chromadb_local/chromadb_vector_store.py
@@ -267,7 +267,11 @@ class ChromaDBLocalVectorStore:
                 file,
                 self.collection_name,
             )
-            await self._store_chunks(collection, chunks, file.metadata)
+            await self._store_chunks(
+                collection,
+                chunks,
+                {**file.metadata, "external_id": file.external_id},
+            )
 
     async def _store_chunks(
         self, collection, chunks: list[dict], source_metadata: dict | None = None
@@ -312,6 +316,10 @@ class ChromaDBLocalVectorStore:
             }
             for i, chunk in enumerate(chunks)
         ]
+
+        # Drop any previous version first: doc_id is derived from the item's
+        # external_id, so without this an edited item would be indexed twice.
+        await collection.delete(where={"doc_id": doc_id})
 
         # Write in batches under ChromaDB's max add() size (see _ADD_BATCH_SIZE).
         documents = [chunk["text"] for chunk in chunks]

--- a/packages/spaces/backend/tests/test_chunk_storage_batching.py
+++ b/packages/spaces/backend/tests/test_chunk_storage_batching.py
@@ -18,6 +18,13 @@ class _FakeCollection:
     def __init__(self):
         self.batch_sizes: list[int] = []
         self.all_ids: list[str] = []
+        self.deleted_where: list[dict] = []
+
+    async def delete(self, where):
+        # Must land before any add: the delete is what replaces the previous
+        # version rather than leaving it alongside the new one.
+        assert not self.all_ids
+        self.deleted_where.append(where)
 
     async def add(self, ids, documents, embeddings, metadatas):
         # Every batch must be self-consistent and within the cap.
@@ -60,6 +67,12 @@ async def test_large_input_is_split_into_capped_batches():
     # Every chunk written exactly once, ids unique and complete.
     assert len(coll.all_ids) == n
     assert coll.all_ids == [f"doc_{i}" for i in range(n)]
+
+
+async def test_previous_version_is_deleted_before_adding():
+    """Without this an edited item is indexed twice, old chunks and new."""
+    coll = await _store(3)
+    assert coll.deleted_where == [{"doc_id": "doc"}]
 
 
 async def test_small_input_is_one_batch():

--- a/packages/spaces/backend/tests/test_docling_backends.py
+++ b/packages/spaces/backend/tests/test_docling_backends.py
@@ -203,7 +203,7 @@ def test_remote_backend_produces_chunks(tmp_path):
     backend = RemoteDoclingBackend(fake)  # type: ignore[arg-type]
     source = tmp_path / "a.docx"
     source.write_bytes(b"fake")
-    file = IngestFile(path=source, filename="a.docx", file_size=4)
+    file = IngestFile(external_id="item-1", path=source, filename="a.docx", file_size=4)
 
     chunks = backend.convert_to_chunks(
         file, tmp_path / "images", "doc1", _heuristic_chunker
@@ -222,7 +222,7 @@ def test_remote_backend_pdf_timeout_scales_with_pages(tmp_path, monkeypatch):
     monkeypatch.setattr(docling_remote, "_get_pdf_page_count", lambda _: 5)
     source = tmp_path / "a.pdf"
     source.write_bytes(b"fake")
-    file = IngestFile(path=source, filename="a.pdf", file_size=4)
+    file = IngestFile(external_id="item-1", path=source, filename="a.pdf", file_size=4)
 
     backend.convert_to_chunks(file, tmp_path / "images", "doc1", _heuristic_chunker)
 
@@ -238,7 +238,7 @@ def test_remote_backend_empty_pdf_result_raises(tmp_path, monkeypatch):
     monkeypatch.setattr(docling_remote, "_get_pdf_page_count", lambda _: 1)
     source = tmp_path / "a.pdf"
     source.write_bytes(b"fake")
-    file = IngestFile(path=source, filename="a.pdf", file_size=4)
+    file = IngestFile(external_id="item-1", path=source, filename="a.pdf", file_size=4)
 
     with pytest.raises(ConversionError, match="All pages failed"):
         backend.convert_to_chunks(file, tmp_path / "images", "doc1", _heuristic_chunker)
@@ -271,7 +271,9 @@ def test_facade_txt_shortcut_bypasses_backend(tmp_path, _reset_backend):
     DocumentChunker._backend = _Exploding()
     source = tmp_path / "notes.txt"
     source.write_text("plain text")
-    file = IngestFile(path=source, filename="notes.txt", file_size=10)
+    file = IngestFile(
+        external_id="item-1", path=source, filename="notes.txt", file_size=10
+    )
 
     chunks = DocumentChunker().parse_document(file, "col")
 
@@ -284,7 +286,7 @@ def test_facade_delegates_docling_formats_to_backend(tmp_path, _reset_backend):
     DocumentChunker._backend = backend
     source = tmp_path / "a.docx"
     source.write_bytes(b"fake")
-    file = IngestFile(path=source, filename="a.docx", file_size=4)
+    file = IngestFile(external_id="item-1", path=source, filename="a.docx", file_size=4)
 
     DocumentChunker().parse_document(file, "col")
 

--- a/packages/spaces/backend/tests/test_ingest_metadata.py
+++ b/packages/spaces/backend/tests/test_ingest_metadata.py
@@ -8,10 +8,12 @@ so every date and author was discarded at ingest.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timezone
 
 import pytest
 
+from syft_space.components.chunking.chunker import derive_doc_id
 from syft_space.components.shared.timestamps import parse_datetime
 from syft_space.components.vector_stores.chromadb_local.chromadb_vector_store import (
     _chroma_scalars,
@@ -125,6 +127,49 @@ class TestSourcesEmitDatetimes:
         stored = _chroma_scalars(meta)
         assert stored["published_ts"] == 1517989560
         assert stored["tags"] == "ml"
+
+
+class TestDocumentIdentity:
+    """doc_id is derived, so re-ingesting replaces rather than duplicates."""
+
+    def test_same_item_yields_the_same_id(self):
+        assert derive_doc_id("1:10") == derive_doc_id("1:10")
+
+    def test_different_items_differ(self):
+        assert derive_doc_id("1:10") != derive_doc_id("1:11")
+
+    def test_shape_matches_what_the_image_route_accepts(self):
+        # handlers.serve_image validates ^[a-f0-9]{16}$.
+        assert re.fullmatch(r"[a-f0-9]{16}", derive_doc_id("1:10"))
+
+    async def test_external_id_is_stored_for_every_source(self, monkeypatch):
+        # A hash cannot be reversed, so the id itself has to be recorded to
+        # map a search hit back to the source item.
+        import httpx
+
+        from syft_space.components.sources.blogspot import blogspot_source as bs
+
+        def handler(request):
+            return httpx.Response(
+                200,
+                json={"id": "10", "title": "T", "content": "<p>x</p>"},
+                request=request,
+            )
+
+        monkeypatch.setattr(
+            bs,
+            "_make_client",
+            lambda: httpx.AsyncClient(
+                base_url=bs.BLOGGER_API_ROOT, transport=httpx.MockTransport(handler)
+            ),
+        )
+        source = bs.BlogspotSource(
+            bs.BlogspotDatasetConfig.model_validate(
+                {"blogUrls": "https://example.blogspot.com", "apiKey": "k"}
+            )
+        )
+        async with source.fetch("1:10") as ingest_file:
+            assert ingest_file.external_id == "1:10"
 
 
 class TestCanonicalFields:

--- a/packages/spaces/backend/tests/test_ingest_metadata.py
+++ b/packages/spaces/backend/tests/test_ingest_metadata.py
@@ -124,7 +124,92 @@ class TestSourcesEmitDatetimes:
 
         stored = _chroma_scalars(meta)
         assert stored["published_ts"] == 1517989560
-        assert stored["labels"] == "ml"
+        assert stored["tags"] == "ml"
+
+
+class TestCanonicalFields:
+    """Sources agree on names for the same concepts, so a future filter can
+    target one key across sources instead of `link` here and `url` there."""
+
+    async def test_wordpress_fills_the_canonical_set(self, monkeypatch):
+        import httpx
+
+        from syft_space.components.sources.wordpress import wordpress_source as wp
+
+        post = {
+            "id": 7,
+            "slug": "hello",
+            "link": "https://example.com/hello",
+            "date_gmt": "2024-01-10T09:00:00",
+            "modified_gmt": "2024-01-15T10:30:00",
+            "title": {"rendered": "Hello"},
+            "content": {"rendered": "<p>body</p>"},
+            "author": 227158,
+            "status": "publish",
+            "_embedded": {
+                "author": [{"name": "Nicholas Garofalo"}],
+                "wp:term": [
+                    [{"name": "Community"}, {"name": "Events"}],
+                    [{"name": "WCUS"}],
+                ],
+            },
+        }
+
+        def handler(request):
+            if request.url.path.endswith("/types"):
+                return httpx.Response(
+                    200,
+                    json={
+                        "post": {
+                            "slug": "post",
+                            "name": "Posts",
+                            "rest_base": "posts",
+                            "viewable": True,
+                        }
+                    },
+                    request=request,
+                )
+            return httpx.Response(200, json=post, request=request)
+
+        monkeypatch.setattr(
+            wp,
+            "_make_client",
+            lambda _cfg: httpx.AsyncClient(
+                base_url="https://example.com/wp-json/wp/v2",
+                transport=httpx.MockTransport(handler),
+            ),
+        )
+        source = wp.WordPressSource(
+            wp.WordPressDatasetConfig.model_validate(
+                {
+                    "siteUrl": "https://example.com",
+                    "username": "u",
+                    "applicationPassword": "p",
+                }
+            )
+        )
+        async with source.fetch("post:7") as ingest_file:
+            meta = ingest_file.metadata
+
+        assert meta["url"] == "https://example.com/hello"
+        # A display name, not the numeric id the bare field carries.
+        assert meta["author"] == "Nicholas Garofalo"
+        assert meta["author_id"] == 227158
+        # Categories and tags flattened into one canonical list of names.
+        assert meta["tags"] == ["Community", "Events", "WCUS"]
+        assert isinstance(meta["published"], datetime)
+        assert isinstance(meta["updated"], datetime)
+
+        stored = _chroma_scalars(meta)
+        assert stored["published_ts"] == 1704877200
+        assert stored["tags"] == "Community,Events,WCUS"
+
+    async def test_missing_embed_degrades_quietly(self):
+        from syft_space.components.sources.wordpress import wordpress_source as wp
+
+        # A site that does not honour _embed must not break the ingest.
+        assert wp._embedded_author({"author": 1}) is None
+        assert wp._embedded_terms({"categories": [3]}) == []
 
 
 class TestStoredChunkMetadata:

--- a/packages/spaces/backend/tests/test_ingest_metadata.py
+++ b/packages/spaces/backend/tests/test_ingest_metadata.py
@@ -1,0 +1,165 @@
+"""Source metadata must survive ingestion and be queryable.
+
+Sources record what they know about an item — publication date, author,
+link — in ``IngestFile.metadata``. That dict was passed to the chunker and
+then dropped: the stored chunk metadata was built only from chunker output,
+so every date and author was discarded at ingest.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from syft_space.components.shared.timestamps import parse_datetime
+from syft_space.components.vector_stores.chromadb_local.chromadb_vector_store import (
+    _chroma_scalars,
+)
+
+
+class TestParseDatetime:
+    @pytest.mark.parametrize(
+        ("label", "raw", "expected"),
+        [
+            (
+                "RSS pubDate",
+                "Tue, 25 Aug 2026 21:35:11 +0000",
+                "2026-08-25T21:35:11+00:00",
+            ),
+            (
+                "Atom offset",
+                "2018-02-06T23:46:00.000-08:00",
+                "2018-02-07T07:46:00+00:00",
+            ),
+            ("Blogger Z", "2024-03-01T00:00:00Z", "2024-03-01T00:00:00+00:00"),
+            ("WP naive gmt", "2024-01-15T10:30:00", "2024-01-15T10:30:00+00:00"),
+        ],
+    )
+    def test_real_source_formats(self, label, raw, expected):
+        assert parse_datetime(raw).isoformat() == expected
+
+    def test_naive_values_are_utc_not_local(self):
+        # WordPress *_gmt fields carry no offset. Reading them as local time
+        # shifts every date by the server's offset.
+        assert parse_datetime("2024-01-15T10:30:00").tzinfo == timezone.utc
+
+    @pytest.mark.parametrize("bad", ["", None, "not a date", "2024"])
+    def test_unparseable_values_are_dropped_not_raised(self, bad):
+        # A missing date is not worth failing an ingest over.
+        assert parse_datetime(bad) is None
+
+
+class TestChromaScalars:
+    def test_datetime_yields_iso_and_epoch(self):
+        # Metadata filtering compares numbers, so the epoch int is what makes
+        # a date range queryable at all.
+        out = _chroma_scalars({"published": datetime(2024, 3, 1, tzinfo=timezone.utc)})
+        assert out["published"] == "2024-03-01T00:00:00+00:00"
+        assert out["published_ts"] == 1709251200
+
+    def test_naive_datetime_is_read_as_utc(self):
+        out = _chroma_scalars({"published": datetime(2024, 1, 15, 10, 30)})
+        assert out["published"] == "2024-01-15T10:30:00+00:00"
+        assert out["published_ts"] == 1705314600
+
+    def test_lists_are_joined(self):
+        # ChromaDB rejects list values outright.
+        assert _chroma_scalars({"labels": ["ml", "nlp"]})["labels"] == "ml,nlp"
+
+    def test_none_is_dropped(self):
+        assert "author" not in _chroma_scalars({"author": None})
+
+    def test_scalars_pass_through(self):
+        out = _chroma_scalars({"s": "x", "i": 1, "f": 1.5, "b": True})
+        assert out == {"s": "x", "i": 1, "f": 1.5, "b": True}
+
+    def test_unknown_types_are_stringified(self):
+        assert _chroma_scalars({"o": {"a": 1}})["o"] == "{'a': 1}"
+
+    def test_empty_metadata_is_empty(self):
+        assert _chroma_scalars({}) == {}
+
+
+class TestSourcesEmitDatetimes:
+    """Sources hand over a datetime; the store decides how to serialize it."""
+
+    async def test_blogspot_fetch_metadata_carries_datetimes(self, monkeypatch):
+        import httpx
+
+        from syft_space.components.sources.blogspot import blogspot_source as bs
+
+        post = {
+            "id": "10",
+            "title": "Hello",
+            "content": "<p>body</p>",
+            "url": "https://example.blogspot.com/p/10",
+            "updated": "2024-03-01T00:00:00Z",
+            "published": "2018-02-06T23:46:00.000-08:00",
+            "labels": ["ml"],
+        }
+
+        def handler(request):
+            return httpx.Response(200, json=post, request=request)
+
+        monkeypatch.setattr(
+            bs,
+            "_make_client",
+            lambda: httpx.AsyncClient(
+                base_url=bs.BLOGGER_API_ROOT, transport=httpx.MockTransport(handler)
+            ),
+        )
+        source = bs.BlogspotSource(
+            bs.BlogspotDatasetConfig.model_validate(
+                {"blogUrls": "https://example.blogspot.com", "apiKey": "k"}
+            )
+        )
+        async with source.fetch("1:10") as ingest_file:
+            meta = ingest_file.metadata
+
+        assert isinstance(meta["updated"], datetime)
+        assert isinstance(meta["published"], datetime)
+        # The fingerprint keeps the raw string it compares on.
+        assert source.fingerprint("1:10") == "2024-03-01T00:00:00Z"
+
+        stored = _chroma_scalars(meta)
+        assert stored["published_ts"] == 1517989560
+        assert stored["labels"] == "ml"
+
+
+class TestStoredChunkMetadata:
+    """The merge in ``_store_chunks``, without a live ChromaDB."""
+
+    @staticmethod
+    def _merge(source_metadata: dict) -> dict:
+        """Mirror the dict build in _store_chunks for one chunk."""
+        extra = _chroma_scalars(source_metadata)
+        return {
+            **extra,
+            "doc_id": "abc123",
+            "chunk_index": 0,
+            "file_name": "post.html",
+            "file_type": ".html",
+        }
+
+    def test_source_metadata_reaches_the_chunk(self):
+        merged = self._merge(
+            {
+                "source": "wordpress",
+                "link": "https://example.com/p/1",
+                "modified_gmt": datetime(2024, 1, 15, 10, 30, tzinfo=timezone.utc),
+                "tags": [4, 7],
+                "author": None,
+            }
+        )
+        assert merged["source"] == "wordpress"
+        assert merged["link"] == "https://example.com/p/1"
+        assert merged["modified_gmt_ts"] == 1705314600
+        assert merged["tags"] == "4,7"
+        assert "author" not in merged
+
+    def test_structural_keys_win_a_clash(self):
+        # A source setting doc_id must not be able to break chunk identity.
+        merged = self._merge({"doc_id": "hijacked", "file_name": "evil"})
+        assert merged["doc_id"] == "abc123"
+        assert merged["file_name"] == "post.html"


### PR DESCRIPTION
This pull request significantly improves how metadata from source documents (such as publication date, author, and tags) is handled throughout the ingestion pipeline. The main changes ensure that sources emit structured metadata (not just raw strings), that this metadata is preserved and appropriately serialized for storage and querying in ChromaDB, and that the system is robustly tested for these behaviors.

**Key improvements include:**

* Sources now parse and emit standardized datetime objects instead of raw strings.
* The ingestion pipeline preserves all source metadata and serializes it into scalar types compatible with ChromaDB, including special handling for datetimes and lists.
* Metadata fields are made canonical across sources for easier downstream filtering and querying.
* Comprehensive tests are added to ensure correct metadata handling and serialization.

---

**Metadata handling and standardization:**

- Introduced `parse_datetime` in `timestamps.py` to parse various upstream date formats into UTC-aware `datetime` objects, ensuring consistency and robustness across sources.
- Updated Blogspot and WordPress sources to emit datetimes and canonical metadata fields (`title`, `url`, `author`, `tags`, etc.) in `IngestFile.metadata`, replacing raw strings and source-specific field names. [[1]](diffhunk://#diff-a05f68df9cbb31faeaf88e20d36ef1ac7d4d3bf382edc8d96cbc3de5e157294bR56) [[2]](diffhunk://#diff-a05f68df9cbb31faeaf88e20d36ef1ac7d4d3bf382edc8d96cbc3de5e157294bL564-R570) [[3]](diffhunk://#diff-6aca75858f45863bbc3f6e752311d02a6b168c0711513446bdef047e856cf871R35) [[4]](diffhunk://#diff-6aca75858f45863bbc3f6e752311d02a6b168c0711513446bdef047e856cf871R413-R418) [[5]](diffhunk://#diff-6aca75858f45863bbc3f6e752311d02a6b168c0711513446bdef047e856cf871R445-R459)
- Local file source now includes file modification time as a UTC-aware datetime in metadata.

**Vector store ingestion and serialization:**

- Added `_chroma_scalars` utility to convert metadata into ChromaDB-compatible scalar types: datetimes become both ISO strings and epoch integers, lists are joined, and unsupported types are stringified. [[1]](diffhunk://#diff-21444d4f4bcc11a5cc756823e6eec1be29d566719f9036888e362fc8bae449a2R12) [[2]](diffhunk://#diff-21444d4f4bcc11a5cc756823e6eec1be29d566719f9036888e362fc8bae449a2R103-R127)
- Modified the ChromaDB ingestion pipeline to merge all source metadata into each chunk's metadata, ensuring no information is lost and structural keys are preserved. [[1]](diffhunk://#diff-21444d4f4bcc11a5cc756823e6eec1be29d566719f9036888e362fc8bae449a2L244-R280) [[2]](diffhunk://#diff-21444d4f4bcc11a5cc756823e6eec1be29d566719f9036888e362fc8bae449a2L267-R301)

**Testing and validation:**

- Added a comprehensive test suite in `test_ingest_metadata.py` to verify:
  - Datetime parsing and handling edge cases.
  - ChromaDB scalar serialization for all supported types.
  - Canonical metadata fields across sources.
  - End-to-end preservation of metadata through the ingestion pipeline.
 

**WordPress-specific enhancements:**

- Added helpers to extract display names for authors and canonical tag/category names from embedded API responses, ensuring consistent metadata regardless of source quirks.

These changes make the metadata pipeline more robust, queryable, and consistent, paving the way for advanced filtering and analytics on ingested documents.